### PR TITLE
[DRAFT] - fix resourceNamespaceFileDelete URL generation

### DIFF
--- a/internal/provider/resource_namespace_file.go
+++ b/internal/provider/resource_namespace_file.go
@@ -153,7 +153,7 @@ func resourceNamespaceFileDelete(ctx context.Context, d *schema.ResourceData, me
 	namespace, filename := namespaceFileConvertId(d.Id())
 	tenantId := c.TenantId
 
-	url := fmt.Sprintf("%s/namespaces/%s/files?path=%s", apiRoot(tenantId), namespace, filename)
+	url := c.Url + fmt.Sprintf("%s/namespaces/%s/files?path=%s", apiRoot(tenantId), namespace, filename)
 
 	_, reqErr := c.request("DELETE", url, nil)
 	if reqErr != nil {


### PR DESCRIPTION
This is not ready, working on QAing it, with local terraform provider. No review yet please


<!-- Thanks for submitting a Pull Request to kestra. To help us review your contribution, please follow the guidelines below:

- Make sure that your commits follow the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) specification e.g. `feat(ui): add a new navigation menu item` or `fix(core): fix a bug in the core model` or `docs: update the README.md`. This will help us automatically generate the changelog.
- The title should briefly summarize the proposed changes.
- Provide a short overview of the change and the value it adds.
- Share a flow example to help the reviewer understand and QA the change.
- Use "close" to automatically close an issue. For example, `close #1234` will close issue #1234. -->

### What changes are being made and why?
<!-- Please include a brief summary of the changes included in this PR e.g. closes #1234. -->
- URL isn't correct so delete action has client HTTP timeout

---

### How the changes have been QAed?
- no I need help QAing. I do not know how to QA a custom Terraform project

<!-- Include example code that shows how this PR has been QAed. The code should present a complete yet easily reproducible flow.

```yaml
# Your example flow code here
```

Note that this is not a replacement for unit tests but rather a way to demonstrate how the changes work in a real-life scenario, as the end-user would experience them.

Remove this section if this change applies to all flows or to the documentation only. -->

---

### Setup Instructions

<!--If there are any setup requirements like API keys or trial accounts, kindly include brief bullet-points-description outlining the setup process below.

- [External System Documentation](URL)
- Steps to set up the necessary resources

If there are no setup requirements, you can remove this section.

Thank you for your contribution. ❤️  -->
