### PR TITLE
feat(provider)!: make provider compatible with Kestra 0.23

### DIFF
--- a/.github/docker/application.yml
+++ b/.github/docker/application.yml
@@ -3,15 +3,18 @@ kestra:
      super-admin:
        username: root@root.com
        password: Root!1234
+       tenantAdminAccess: main
   encryption:
     secret-key: LWBErwwlb/BQcxWujsm+/scPeO01cTKzvW44GbAWvII=
-  kafka:
+  kafka: 
     client:
       properties:
         bootstrap.servers: kafka:9092
   elasticsearch:
     client:
       http-hosts: http://elasticsearch:9200
+    defaults:
+      indice-prefix: "kestra_"
   repository:
     type: elasticsearch
   storage:

--- a/.github/docker/application.yml
+++ b/.github/docker/application.yml
@@ -13,8 +13,6 @@ kestra:
   elasticsearch:
     client:
       http-hosts: http://elasticsearch:9200
-    defaults:
-      indice-prefix: "kestra_"
   repository:
     type: elasticsearch
   storage:

--- a/.github/workflows/index.jsonl
+++ b/.github/workflows/index.jsonl
@@ -30,3 +30,6 @@
 
 { "index" : { "_index" : "kestra_users", "_id" : "2EPi5XC0oluKRCVF56gcC" } }
 {"id":"2EPi5XC0oluKRCVF56gcC","username":"test-sa", "type": "SERVICE_ACCOUNT", "auths":[{"type" : "io.kestra.ee.models.auths.ApiTokenAuth", "uid" : "2XDKrmqyHDkoGnU11wlj87", "tokenPrefix" : "TCAMX5", "name" : "test", "description" : "test", "iat" : "2024-01-01T00:00:00Z", "maxAge" : 86400.0, "lastUsed" : "2024-01-01T00:00:00Z", "extended" : false}],"deleted":false}
+
+{ "index" : { "_index" : "kestra_worker_groups", "_id" : "1RgkLgU0oUXndtPswzaFku" } }
+{ "uid": "1RgkLgU0oUXndtPswzaFku", "key": "WorkerGroupKey-1", "description": "my WorkerGroupKey-1 desc", "deleted": false}

--- a/.github/workflows/index.jsonl
+++ b/.github/workflows/index.jsonl
@@ -1,5 +1,5 @@
 { "index" : { "_index" : "kestra_roles", "_id" : "admin" } }
-{"id":"admin","name":"Admin", "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"],"KVSTORE":["READ","CREATE","UPDATE","DELETE"], "INFRASTRUCTURE":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
+{"id":"admin","name":"Admin", "tenantId":"main",      "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"],"KVSTORE":["READ","CREATE","UPDATE","DELETE"], "INFRASTRUCTURE":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
 { "index" : { "_index" : "kestra_roles", "_id" : "admin2" } }
 {"id":"admin2","name":"Admin","tenantId":"unit_test", "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
 { "index" : { "_index" : "kestra_groups", "_id" : "admin" } }
@@ -13,7 +13,7 @@
 { "index" : { "_index" : "kestra_templates", "_id" : "io.kestra.terraform.data_simple" } }
 {"id":"simple","namespace":"io.kestra.terraform.data","tasks":[{"id":"t1","type":"io.kestra.core.tasks.log.Log","message":"first {{task.id}}","level":"TRACE"},{"id":"t2","type":"io.kestra.core.tasks.log.Log","disabled":true,"message":"second {{task.type}}","level":"WARN"},{"id":"t3","type":"io.kestra.core.tasks.log.Log","message":"third {{flow.id}}","level":"ERROR"}],"deleted":false}
 { "index" : { "_index" : "kestra_bindings", "_id" : "john" } }
-{"id":"john","type":"USER","externalId":"john","roleId":"admin","deleted":false}
+{"id":"john","type":"USER","externalId":"john","roleId":"admin","tenantId":"main",      "deleted":false}
 { "index" : { "_index" : "kestra_bindings", "_id" : "john2" } }
 {"id":"john2","type":"USER","externalId":"john","roleId":"admin","tenantId":"unit_test","deleted":false}
 { "index" : { "_index" : "kestra_tenants", "_id" : "admin" } }

--- a/.github/workflows/index.jsonl
+++ b/.github/workflows/index.jsonl
@@ -1,24 +1,32 @@
 { "index" : { "_index" : "kestra_roles", "_id" : "admin" } }
-{"id":"admin","name":"Admin", "tenantId":"main",      "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"],"KVSTORE":["READ","CREATE","UPDATE","DELETE"], "INFRASTRUCTURE":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
+{"id":"admin", "tenantId":"main", "name":"Admin", "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"],"KVSTORE":["READ","CREATE","UPDATE","DELETE"], "INFRASTRUCTURE":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
+
 { "index" : { "_index" : "kestra_roles", "_id" : "admin2" } }
-{"id":"admin2","name":"Admin","tenantId":"unit_test", "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
+{"id":"admin2", "tenantId":"unit_test", "name":"Admin", "isDefault": false,"permissions":{"FLOW":["READ","CREATE","UPDATE","DELETE"],"TEMPLATE":["READ","CREATE","UPDATE","DELETE"],"EXECUTION":["READ","CREATE","UPDATE","DELETE"],"USER":["READ","CREATE","UPDATE","DELETE"],"NAMESPACE":["READ","CREATE","UPDATE","DELETE"],"GROUP":["READ","CREATE","UPDATE","DELETE"],"ROLE":["READ","CREATE","UPDATE","DELETE"],"AUDITLOG":["READ"],"SECRET":["READ","CREATE","UPDATE","DELETE"],"BINDING":["READ","CREATE","UPDATE","DELETE"],"TENANT":["READ","CREATE","UPDATE","DELETE"]},"deleted":false}
+
 { "index" : { "_index" : "kestra_groups", "_id" : "admin" } }
-{"id":"admin","name":"Group Admin","description":"My description","deleted":false}
+{"id":"admin", "tenantId":"main", "name":"Group Admin", "description":"My description","deleted":false}
+
 { "index" : { "_index" : "kestra_users", "_id" : "john" } }
 {"id":"john","username":"john@doe.com","auths":[{"type":"io.kestra.ee.models.auths.BasicAuth","salt":"0ghOqlkf41KpHl0D5Hf1Qhu77uiQ4ez3","password":"a74f765210a72aeb690824c1805bc364b71769362afbf7cfd9b1fb7b283902b41f630aee940e3b38058a43552c964293e802a9276e1d501455b39616802953b5","uid":"BasicAuth"}],"groups":["admin"],"deleted":false, "type": "SUPER_ADMIN"}
+
 { "index" : { "_index" : "kestra_flows", "_id" : "io.kestra.terraform.data_simple" } }
-{"id":"simple","namespace":"io.kestra.terraform.data","revision":1,"tasks":[{"id":"t1","type":"io.kestra.core.tasks.log.Log","message":"first {{task.id}}","level":"TRACE"},{"id":"t2","type":"io.kestra.core.tasks.log.Log","disabled":true,"message":"second {{task.type}}","level":"WARN"},{"id":"t3","type":"io.kestra.core.tasks.log.Log","message":"third {{flow.id}}","level":"ERROR"}],"deleted":false}
-{ "index" : { "_index" : "kestra_namespaces", "_id" : "io.kestra.terraform.data" } }
-{"id":"io.kestra.terraform.data","description":"My Kestra Namespace data","deleted":false}
+{"id":"simple", "tenantId":"main", "namespace":"io.kestra.terraform.data","revision":1,"tasks":[{"id":"t1","type":"io.kestra.core.tasks.log.Log","message":"first {{task.id}}","level":"TRACE"},{"id":"t2","type":"io.kestra.core.tasks.log.Log","disabled":true,"message":"second {{task.type}}","level":"WARN"},{"id":"t3","type":"io.kestra.core.tasks.log.Log","message":"third {{flow.id}}","level":"ERROR"}],"deleted":false}
+
 { "index" : { "_index" : "kestra_templates", "_id" : "io.kestra.terraform.data_simple" } }
-{"id":"simple","namespace":"io.kestra.terraform.data","tasks":[{"id":"t1","type":"io.kestra.core.tasks.log.Log","message":"first {{task.id}}","level":"TRACE"},{"id":"t2","type":"io.kestra.core.tasks.log.Log","disabled":true,"message":"second {{task.type}}","level":"WARN"},{"id":"t3","type":"io.kestra.core.tasks.log.Log","message":"third {{flow.id}}","level":"ERROR"}],"deleted":false}
+{"id":"simple", "tenantId":"main", "namespace":"io.kestra.terraform.data","tasks":[{"id":"t1","type":"io.kestra.core.tasks.log.Log","message":"first {{task.id}}","level":"TRACE"},{"id":"t2","type":"io.kestra.core.tasks.log.Log","disabled":true,"message":"second {{task.type}}","level":"WARN"},{"id":"t3","type":"io.kestra.core.tasks.log.Log","message":"third {{flow.id}}","level":"ERROR"}],"deleted":false}
+
 { "index" : { "_index" : "kestra_bindings", "_id" : "john" } }
-{"id":"john","type":"USER","externalId":"john","roleId":"admin","tenantId":"main",      "deleted":false}
+{"id":"john", "tenantId":"main", "type":"USER","externalId":"john","roleId":"admin", "deleted":false}
+
 { "index" : { "_index" : "kestra_bindings", "_id" : "john2" } }
-{"id":"john2","type":"USER","externalId":"john","roleId":"admin","tenantId":"unit_test","deleted":false}
+{"id":"john2", "tenantId":"unit_test", "type":"USER","externalId":"john","roleId":"admin","deleted":false}
+
 { "index" : { "_index" : "kestra_tenants", "_id" : "admin" } }
 {"id":"admin","name":"My admin tenants","deleted":false}
+
 { "index" : { "_index" : "kestra_tenants", "_id" : "unit_test" } }
 {"id":"unit_test","name":"My admin tenants","deleted":false}
+
 { "index" : { "_index" : "kestra_users", "_id" : "2EPi5XC0oluKRCVF56gcC" } }
 {"id":"2EPi5XC0oluKRCVF56gcC","username":"test-sa", "type": "SERVICE_ACCOUNT", "auths":[{"type" : "io.kestra.ee.models.auths.ApiTokenAuth", "uid" : "2XDKrmqyHDkoGnU11wlj87", "tokenPrefix" : "TCAMX5", "name" : "test", "description" : "test", "iat" : "2024-01-01T00:00:00Z", "maxAge" : 86400.0, "lastUsed" : "2024-01-01T00:00:00Z", "extended" : false}],"deleted":false}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,17 @@ on:
   push:
     paths-ignore:
       - 'README.md'
+    branches:
+      - main
+      - 'releases/**'
+    tags:
+      - 'v*'
   # schedule:
   #   - cron: '0 13 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -41,9 +50,9 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
+          - '1.7.5'
           - '1.8.5'
           - '1.9.8'
-          - '1.10.5'
 
     steps:
       - name: Check out code into the Go module directory
@@ -56,41 +65,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+
+
       - name: Build the docker-compose stack
         env:
           APPLICATION_SECRETS: ${{ secrets.APPLICATION_SECRETS }}
         run: |
           echo $APPLICATION_SECRETS | base64 -d > .github/docker/application-secrets.yml
-          docker compose -f docker-compose-ci.yml pull
-          docker compose -f docker-compose-ci.yml up -d zookeeper kafka elasticsearch vault
-          sleep 30
-          docker compose -f docker-compose-ci.yml up -d
-          sleep 30
-
-          echo "\echo 'path \"*\" {capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"]}' | vault policy write admins -" | docker exec --interactive terraform-provider-kestra-vault-1 sh -
-          docker compose -f docker-compose-ci.yml exec vault vault auth enable userpass
-          docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/users/john \
-              password=foo \
-              policies=admins \
-              token_period=1s
-
-          curl "127.27.27.27:9200" > /dev/null
-          curl -X POST "127.27.27.27:8080/api/v1/users" > /dev/null
-          curl -u root@root.com:Root!1234 -X POST -H 'Content-Type: application/json' -d '{"id":"unit_test","name":"Unit Test"}' "127.27.27.27:8080/api/v1/tenants" > /dev/null
-          curl -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl
-          sleep 3
-          curl -H "Content-Type: multipart/form-data" -u root@root.com:Root!1234 -X POST -F fileContent=@internal/resources/flow.py "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/files?path=/flow.py"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/string"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d '1' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/int"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d '1.5' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/double"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d 'false' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/falseBoolean"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d 'true' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/trueBoolean"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d '2022-05-01T03:02:01Z' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/dateTime"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d '2022-05-01' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/date"
-          curl -H "Content-Type: text/plain" -u root@root.com:Root!1234 -X PUT -d 'P3DT3H2M1S' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/duration"
-          curl -H "Content-Type: application/json" -u root@root.com:Root!1234 -X PUT -d '{"some":"value","in":"object"}' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/object"
-          curl -H "Content-Type: application/json" -u root@root.com:Root!1234 -X PUT -d '[{"some":"value","in":"object"},{"yet":"another","array":"object"}]' "127.27.27.27:8080/api/v1/namespaces/io.kestra.terraform.data/kv/array"
-
+          
+          sh init-tests-env.sh
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,9 +50,10 @@ jobs:
       fail-fast: false
       matrix:
         terraform:
-          - '1.7.5'
           - '1.8.5'
           - '1.9.8'
+          - '1.10.5'
+          - '1.12.2'
 
     steps:
       - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -37,24 +37,14 @@
 
 This repository defines Kestra resources so that they can be deployed using Infrastructure as Code with Terraform.
 
-![Kestra orchestrator](https://kestra.io/video.gif)
+> [!IMPORTANT]  
+> Kestra Terraform provider 0.23.x is only compatible with Kestra 0.23.x and above.
+> Additionally, if you want to terraform Kestra 0.23.x you need to use Kestra Terraform provider 0.23.x
 
 ## Documentation
 
 * The official Kestra documentation can be found under [kestra.io/docs](https://kestra.io/docs)
 * Kestra Terraform provider documentation can be found [here](https://kestra.io/docs/terraform/).
-
-
-## License
-Apache 2.0 © [Kestra Technologies](https://kestra.io)
-
-
-## Stay up to date
-
-We release new versions every month. Give the [main repository](https://github.com/kestra-io/kestra) a star to stay up to date with the latest releases and get notified about future updates.
-
-![Star the repo](https://kestra.io/star.gif)
-
 
 
 ## Using the provider
@@ -139,3 +129,13 @@ go mod tidy
 ```
 
 Then commit the changes to `go.mod` and `go.sum`.
+
+
+## Stay up to date
+
+We release new versions every month. Give the [main repository](https://github.com/kestra-io/kestra) a star to stay up to date with the latest releases and get notified about future updates.
+
+![Star the repo](https://kestra.io/star.gif)
+
+## License
+Apache 2.0 © [Kestra Technologies](https://kestra.io)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,19 @@ $ make testacc
 $ go install
 ```
 
+### Start tests in local
+The full test suite requires to start the full [docker-compose-ci.yml](docker-compose-ci.yml) and have access to Kestra EE docker image:
+
+1. read and do requirements of [init-tests-env.sh](init-tests-env.sh)
+2. init test environment 
+```sh 
+$ ./init-tests-env.sh
+```
+3. run tests
+```sh
+$ TF_ACC=1 KESTRA_URL=http://127.0.0.1:8088 KESTRA_USERNAME=root@root.com KESTRA_PASSWORD='Root!1234' go test -v -cover ./internal/provider/
+```
+
 ### Adding Dependencies
 
 This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,19 @@ $ ./init-tests-env.sh
 ```sh
 $ TF_ACC=1 KESTRA_URL=http://127.0.0.1:8088 KESTRA_USERNAME=root@root.com KESTRA_PASSWORD='Root!1234' go test -v -cover ./internal/provider/
 ```
+#### Test coverage
+To display generate a test coverage file in local you can add `-coverprofile` to your test command:
+```
+go test -v -coverprofile=test-coverage-result.out ./internal/provider/
+```
+and then to display it:
+```
+# in browser
+$ go tool cover -html=test-coverage-result.out
 
+# in terminal
+$ go tool cover -func=test-coverage-result.out
+```
 ### Adding Dependencies
 
 This provider uses [Go modules](https://github.com/golang/go/wiki/Modules).

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -4,8 +4,9 @@ services:
     healthcheck:
       test: [ "CMD-SHELL", "kafka-cluster cluster-id --bootstrap-server localhost:9092" ]
       interval: 2s
-      timeout: 30s
-      retries: 10
+      timeout: 10s
+      retries: 30
+      start_period: 5s
     environment:
       KAFKA_KRAFT_MODE: "true"  # This enables KRaft mode in Kafka.
       KAFKA_PROCESS_ROLES: controller,broker  # Kafka acts as both broker and controller.
@@ -27,8 +28,9 @@ services:
     healthcheck:
       test: ["CMD-SHELL", "curl -fs http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
       interval: 2s
-      timeout: 30s
-      retries: 10
+      timeout: 10s
+      retries: 30
+      start_period: 5s
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: "false"
@@ -50,7 +52,8 @@ services:
       test: ["CMD-SHELL", "curl -fs http://localhost:8080/health"]
       interval: 2s
       timeout: 30s
-      retries: 10
+      retries: 30
+      start_period: 5s
     volumes:
       - ./.github/docker/application.yml:/app/confs/application.yml:ro
       - ./.github/docker/application-secrets.yml:/app/secrets/application-secrets.yml:ro
@@ -76,8 +79,9 @@ services:
     healthcheck:
       test: [ "CMD-SHELL", "vault status -format=json | grep '\"initialized\": true'" ]
       interval: 2s
-      timeout: 30s
-      retries: 10
+      timeout: 10s
+      retries: 30
+      start_period: 5s
     environment:
       VAULT_ADDR: http://localhost:8200
       VAULT_API_ADDR: http://localhost:8200

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -43,7 +43,8 @@ services:
 
   kestra:
     image: ghcr.io/kestra-io/kestra-ee:develop
-#    image: europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop it may be easier to use this in local
+    # it may be easier to use gcp registry in local
+#    image: europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop
     command: server standalone
     healthcheck:
       test: ["CMD-SHELL", "curl -fs http://localhost:8080/health"]
@@ -58,7 +59,7 @@ services:
 
     ports:
       - 127.27.27.27:8080:8080
-#      - 8088:8080 use this in local to be able to use/access the kestra app
+      - 8088:8080 # allowing to run tests in local
     links:
       - kafka
       - vault

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -41,9 +41,9 @@ services:
     ports:
       - 127.27.27.27:9200:9200
 
-  kestra: # FIXME revert to develop
+  kestra:
     image: ghcr.io/kestra-io/kestra-ee:develop
-#    image: europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:v0.23.0-rc4-SNAPSHOT
+#    image: europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop it may be easier to use this in local
     command: server standalone
     healthcheck:
       test: ["CMD-SHELL", "curl -fs http://localhost:8080/health"]
@@ -58,6 +58,7 @@ services:
 
     ports:
       - 127.27.27.27:8080:8080
+#      - 8088:8080 use this in local to be able to use/access the kestra app
     links:
       - kafka
       - vault

--- a/docker-compose-ci.yml
+++ b/docker-compose-ci.yml
@@ -1,25 +1,34 @@
 services:
-  zookeeper:
-    image: confluentinc/cp-zookeeper
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-
   kafka:
     image: confluentinc/cp-kafka
+    healthcheck:
+      test: [ "CMD-SHELL", "kafka-cluster cluster-id --bootstrap-server localhost:9092" ]
+      interval: 2s
+      timeout: 30s
+      retries: 10
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_KRAFT_MODE: "true"  # This enables KRaft mode in Kafka.
+      KAFKA_PROCESS_ROLES: controller,broker  # Kafka acts as both broker and controller.
+      KAFKA_NODE_ID: 1  # A unique ID for this Kafka instance.
+      CLUSTER_ID: 'kafka-terraform-provider-cluster-ci-1'
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "1@localhost:9093"  # Defines the controller voters.
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,CONTROLLER://0.0.0.0:9093
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,CONTROLLER:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
       KAFKA_CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
-    links:
-      - zookeeper
-    depends_on:
-      - zookeeper
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:8.2.3
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.17.5
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:9200/_cluster/health | grep -q '\"status\":\"green\"\\|\"status\":\"yellow\"'"]
+      interval: 2s
+      timeout: 30s
+      retries: 10
     environment:
       discovery.type: single-node
       cluster.routing.allocation.disk.threshold_enabled: "false"
@@ -32,9 +41,15 @@ services:
     ports:
       - 127.27.27.27:9200:9200
 
-  kestra:
+  kestra: # FIXME revert to develop
     image: ghcr.io/kestra-io/kestra-ee:develop
+#    image: europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:v0.23.0-rc4-SNAPSHOT
     command: server standalone
+    healthcheck:
+      test: ["CMD-SHELL", "curl -fs http://localhost:8080/health"]
+      interval: 2s
+      timeout: 30s
+      retries: 10
     volumes:
       - ./.github/docker/application.yml:/app/confs/application.yml:ro
       - ./.github/docker/application-secrets.yml:/app/secrets/application-secrets.yml:ro
@@ -45,19 +60,25 @@ services:
       - 127.27.27.27:8080:8080
     links:
       - kafka
-      - zookeeper
       - vault
     depends_on:
-      - kafka
-      - zookeeper
-      - vault
+      kafka:
+        condition: service_healthy
+      vault:
+        condition: service_healthy
 
   vault:
     image: hashicorp/vault
     cap_add:
       - IPC_LOCK
+    healthcheck:
+      test: [ "CMD-SHELL", "vault status -format=json | grep '\"initialized\": true'" ]
+      interval: 2s
+      timeout: 30s
+      retries: 10
     environment:
       VAULT_ADDR: http://localhost:8200
+      VAULT_API_ADDR: http://localhost:8200
       VAULT_TOKEN: my-vault-root-token
       VAULT_LOG_LEVEL: DEBUG
       VAULT_DEV_ROOT_TOKEN_ID: my-vault-root-token

--- a/docs/data-sources/service_account.md
+++ b/docs/data-sources/service_account.md
@@ -35,7 +35,7 @@ data "kestra_user_service_account" "example" {
 ### Read-Only
 
 - `description` (String) The service account description.
-- `username` (String) The service account name.
+- `name` (String) The service account name.
 
 <a id="nestedblock--group"></a>
 ### Nested Schema for `group`

--- a/docs/data-sources/worker_group.md
+++ b/docs/data-sources/worker_group.md
@@ -20,10 +20,10 @@ Use this data source to access information about an existing Kestra Worker Group
 
 ### Required
 
+- `id` (String) The worker group id.
 - `key` (String) The worker group key.
 
 ### Read-Only
 
 - `allowed_tenants` (String) The list of tenants allowed to use the worker group.
 - `description` (String) The worker group description.
-- `id` (String) The worker group id.

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,15 @@ description: |-
 
 # kestra Provider
 
+## Kestra 0.23.x compatibility
+
+!> **Warning:** Kestra Terraform provider 0.23.x is only compatible with Kestra 0.23.x and above.
+
+Additionally, if you want to terraform Kestra 0.23.x you need to use Kestra Terraform provider 0.23.x
+
+### Breaking changes from 0.23.x
+
+`kestra_service_account` resource field `username` was renamed to `name` (see [service_account.md](resources/service_account.md)) 
 
 
 ## Example Usage

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -72,8 +72,11 @@ Required:
 
 Required:
 
-- `fallback` (String) The fallback strategy.
 - `key` (String) The worker group key.
+
+Optional:
+
+- `fallback` (String) The fallback strategy.
 
 ## Import
 

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -17,7 +17,7 @@ Manages a Kestra Service Account.
 
 ```terraform
 resource "kestra_service_account" "example" {
-  username    = "my-service-account"
+  name        = "my-service-account"
   description = "Friendly description"
 }
 ```

--- a/docs/resources/service_account.md
+++ b/docs/resources/service_account.md
@@ -27,7 +27,7 @@ resource "kestra_service_account" "example" {
 
 ### Required
 
-- `username` (String) The service account name.
+- `name` (String) The service account name.
 
 ### Optional
 
@@ -45,7 +45,7 @@ Required:
 
 - `group_id` (String) The group id.
 
-Optional:
+Read-Only:
 
 - `tenant_id` (String) The tenant id for this group.
 

--- a/examples/resources/kestra_service_account/resource.tf
+++ b/examples/resources/kestra_service_account/resource.tf
@@ -1,4 +1,4 @@
 resource "kestra_service_account" "example" {
-  username    = "my-service-account"
+  name        = "my-service-account"
   description = "Friendly description"
 }

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -1,3 +1,6 @@
+#!/bin/bash
+set -e;
+
 echo "initializing test environment with docker compose"
 
 docker compose -f docker-compose-ci.yml up elasticsearch kafka vault -d --wait || {
@@ -20,11 +23,14 @@ docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/use
     policies=admins \
     token_period=1s
 
+
 curl --fail-with-body "127.27.27.27:9200"
+#curl --fail-with-body -u 'root@root.com:Root!1234' -X POST "127.27.27.27:8080/api/v1/main/users"
+curl --fail-with-body -u 'root@root.com:Root!1234' "127.27.27.27:8080/api/v1/main/users/search"
+curl --fail-with-body -u 'root@root.com:Root!1234' -X POST -H 'Content-Type: application/json' -d '{"id":"unit_test","name":"Unit Test"}' "127.27.27.27:8080/api/v1/tenants" > /dev/null
 curl --fail-with-body -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl > /dev/null
 sleep 5
 
-#curl --fail-with-body -X POST "127.27.27.27:8080/api/v1/users"
 
 curl  --fail-with-body -H "Content-Type: multipart/form-data" -u 'root@root.com:Root!1234' -X POST -F "fileContent=@internal/resources/flow.py" "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/files?path=/flow.py" > /dev/null
 curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string"

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -5,7 +5,7 @@
 # DESCRIPTION:
 #   Start and prepare a local Kestra EE + ES env for testing
 #
-# PREREQUISITE:
+# PREREQUISITES/REQUIREMENTS:
 # the Kestra EE licence configuration in .github/docker/application-secrets.yml:
 #     kestra:
 #       ee:
@@ -19,7 +19,7 @@
 # log to GCP registry: echo $(gh auth token) | docker login ghcr.io -u $(gh api user --jq .login) --password-stdin
 #
 #
-# USAGE: ./ init-tests-env.sh
+# USAGE: ./init-tests-env.sh
 # then you can launch the tests with:
 # TF_ACC=1 KESTRA_URL=http://127.0.0.1:8088 KESTRA_USERNAME=root@root.com KESTRA_PASSWORD='Root!1234' go test -v -cover ./internal/provider/
 #
@@ -27,8 +27,12 @@
 
 set -e;
 
-echo "initializing test environment with docker compose"
+echo "starting init-tests-env.sh"
+echo ""
+echo "docker compose down --volumes, need fresh databases"
+docker compose -f docker-compose-ci.yml down --volumes --remove-orphans
 
+echo "initializing test environment with docker compose"
 docker compose -f docker-compose-ci.yml up elasticsearch kafka vault -d --wait || {
    echo "db Docker Compose failed. Dumping logs:";
    docker compose -f docker-compose-ci.yml logs;
@@ -40,9 +44,11 @@ docker compose -f docker-compose-ci.yml up kestra -d --wait || {
    exit 1;
 }
 sleep 10
+echo ""
 echo "start Kestra"
 docker compose -f docker-compose-ci.yml logs kestra;
 
+echo ""
 echo "inject test data in Vault"
 echo "echo 'path \"*\" {capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"]}' | vault policy write admins -" | docker exec --interactive terraform-provider-kestra-vault-1 sh -
 docker compose -f docker-compose-ci.yml exec vault vault auth enable userpass
@@ -51,27 +57,36 @@ docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/use
     policies=admins \
     token_period=1s
 
+echo ""
 echo "do some basic healthchecks"
-curl --fail-with-body "127.27.27.27:9200"
-curl --fail-with-body -u 'root@root.com:Root!1234' "127.27.27.27:8080/api/v1/main/users/search" > /dev/null
+curl --fail-with-body -sS "127.27.27.27:9200" > /dev/null
+curl --fail-with-body -sS -u 'root@root.com:Root!1234' "127.27.27.27:8080/api/v1/main/users/search"
 
-echo "create unit_test using Kestra API"
-curl --fail-with-body -u 'root@root.com:Root!1234' -X POST -H 'Content-Type: application/json' -d '{"id":"unit_test","name":"Unit Test"}' "127.27.27.27:8080/api/v1/tenants" > /dev/null
+echo ""
+echo ""
+echo "create unit_test tenant using Kestra API"
+curl --fail-with-body -sS -u 'root@root.com:Root!1234' -X POST -H 'Content-Type: application/json' -d '{"id":"unit_test","name":"Unit Test"}' "127.27.27.27:8080/api/v1/tenants" > /dev/null
 
+echo ""
 echo "inject most test data directly into ES, yes this is ugly, we should migrate this to using Kestra API or better the new SDK"
-curl --fail-with-body -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl > /dev/null
+curl --fail-with-body -sS -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl  > /dev/null
 sleep 5
 
+echo ""
 echo "inject more test data using Kestra API (namespace, flow.py, kv data)"
-curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X POST -d '{"id":"io.kestra.terraform.data", "tenantId":"main", "description": "My Kestra Namespace data"}' "127.27.27.27:8080/api/v1/main/namespaces" > /dev/null
-curl  --fail-with-body -H "Content-Type: multipart/form-data" -u 'root@root.com:Root!1234' -X POST -F "fileContent=@internal/resources/flow.py" "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/files?path=/flow.py" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/int" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1.5' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/double" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'false' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/falseBoolean" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'true' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/trueBoolean" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01T03:02:01Z' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/dateTime" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/date" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'P3DT3H2M1S' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/duration" > /dev/null
-curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '{"some":"value","in":"object"}' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/object" > /dev/null
-curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '[{"some":"value","in":"object"},{"yet":"another","array":"object"}]' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/array" > /dev/null
+curl  --fail-with-body -sS -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X POST -d '{"id":"io.kestra.terraform.data", "tenantId":"main", "description": "My Kestra Namespace data"}' "127.27.27.27:8080/api/v1/main/namespaces"
+curl  --fail-with-body -sS -H "Content-Type: multipart/form-data" -u 'root@root.com:Root!1234' -X POST -F "fileContent=@internal/resources/flow.py" "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/files?path=/flow.py"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/int"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1.5' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/double"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'false' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/falseBoolean"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'true' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/trueBoolean"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01T03:02:01Z' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/dateTime"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/date"
+curl  --fail-with-body -sS -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'P3DT3H2M1S' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/duration"
+curl  --fail-with-body -sS -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '{"some":"value","in":"object"}' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/object"
+curl  --fail-with-body -sS -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '[{"some":"value","in":"object"},{"yet":"another","array":"object"}]' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/array"
+
+echo ""
+echo "init-tests-env.sh finished successfully"
+echo ""

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -14,6 +14,11 @@
 #           key: |
 #             Ic5OXgAAAB............RVI=
 #
+# in local development you may not have access to the docker image, what you can do:
+# change docker-compose-ci.yml image to europe-west1-docker.pkg.dev/kestra-host/docker/kestra-ee:develop
+# log to GCP registry: echo $(gh auth token) | docker login ghcr.io -u $(gh api user --jq .login) --password-stdin
+#
+#
 # USAGE: ./ init-tests-env.sh
 # then you can launch the tests with:
 # TF_ACC=1 KESTRA_URL=http://127.0.0.1:8088 KESTRA_USERNAME=root@root.com KESTRA_PASSWORD='Root!1234' go test -v -cover ./internal/provider/
@@ -35,8 +40,10 @@ docker compose -f docker-compose-ci.yml up kestra -d --wait || {
    exit 1;
 }
 sleep 10
+echo "start Kestra"
 docker compose -f docker-compose-ci.yml logs kestra;
 
+echo "inject test data in Vault"
 echo "\echo 'path \"*\" {capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"]}' | vault policy write admins -" | docker exec --interactive terraform-provider-kestra-vault-1 sh -
 docker compose -f docker-compose-ci.yml exec vault vault auth enable userpass
 docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/users/john \
@@ -44,24 +51,27 @@ docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/use
     policies=admins \
     token_period=1s
 
-
+echo "do some basic healthchecks"
 curl --fail-with-body "127.27.27.27:9200"
-#curl --fail-with-body -u 'root@root.com:Root!1234' -X POST "127.27.27.27:8080/api/v1/main/users"
 curl --fail-with-body -u 'root@root.com:Root!1234' "127.27.27.27:8080/api/v1/main/users/search" > /dev/null
+
+echo "create unit_test using Kestra API"
 curl --fail-with-body -u 'root@root.com:Root!1234' -X POST -H 'Content-Type: application/json' -d '{"id":"unit_test","name":"Unit Test"}' "127.27.27.27:8080/api/v1/tenants" > /dev/null
+
+echo "inject most test data directly into ES, yes this is ugly, we should migrate this to using Kestra API or better the new SDK"
 curl --fail-with-body -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl > /dev/null
 sleep 5
 
+echo "inject more test data using Kestra API (namespace, flow.py, kv data)"
 curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X POST -d '{"id":"io.kestra.terraform.data", "tenantId":"main", "description": "My Kestra Namespace data"}' "127.27.27.27:8080/api/v1/main/namespaces" > /dev/null
-
 curl  --fail-with-body -H "Content-Type: multipart/form-data" -u 'root@root.com:Root!1234' -X POST -F "fileContent=@internal/resources/flow.py" "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/files?path=/flow.py" > /dev/null
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/int"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1.5' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/double"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'false' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/falseBoolean"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'true' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/trueBoolean"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01T03:02:01Z' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/dateTime"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/date"
-curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'P3DT3H2M1S' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/duration"
-curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '{"some":"value","in":"object"}' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/object"
-curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '[{"some":"value","in":"object"},{"yet":"another","array":"object"}]' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/array"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/int" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1.5' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/double" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'false' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/falseBoolean" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'true' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/trueBoolean" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01T03:02:01Z' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/dateTime" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/date" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'P3DT3H2M1S' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/duration" > /dev/null
+curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '{"some":"value","in":"object"}' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/object" > /dev/null
+curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '[{"some":"value","in":"object"},{"yet":"another","array":"object"}]' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/array" > /dev/null

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -1,4 +1,25 @@
 #!/bin/bash
+#===============================================================================
+# SCRIPT: init-tests-env.sh
+#
+# DESCRIPTION:
+#   Start and prepare a local Kestra EE + ES env for testing
+#
+# PREREQUISITE:
+# the Kestra EE licence configuration in .github/docker/application-secrets.yml:
+#     kestra:
+#       ee:
+#         license:
+#           id: 5dcscsd-dfsdf.........c3
+#           key: |
+#             Ic5OXgAAAB............RVI=
+#
+# USAGE: ./ init-tests-env.sh
+# then you can launch the tests with:
+# TF_ACC=1 KESTRA_URL=http://127.0.0.1:8088 KESTRA_USERNAME=root@root.com KESTRA_PASSWORD='Root!1234' go test -v -cover ./internal/provider/
+#
+#===============================================================================
+
 set -e;
 
 echo "initializing test environment with docker compose"
@@ -26,11 +47,12 @@ docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/use
 
 curl --fail-with-body "127.27.27.27:9200"
 #curl --fail-with-body -u 'root@root.com:Root!1234' -X POST "127.27.27.27:8080/api/v1/main/users"
-curl --fail-with-body -u 'root@root.com:Root!1234' "127.27.27.27:8080/api/v1/main/users/search"
+curl --fail-with-body -u 'root@root.com:Root!1234' "127.27.27.27:8080/api/v1/main/users/search" > /dev/null
 curl --fail-with-body -u 'root@root.com:Root!1234' -X POST -H 'Content-Type: application/json' -d '{"id":"unit_test","name":"Unit Test"}' "127.27.27.27:8080/api/v1/tenants" > /dev/null
 curl --fail-with-body -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl > /dev/null
 sleep 5
 
+curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X POST -d '{"id":"io.kestra.terraform.data", "tenantId":"main", "description": "My Kestra Namespace data"}' "127.27.27.27:8080/api/v1/main/namespaces" > /dev/null
 
 curl  --fail-with-body -H "Content-Type: multipart/form-data" -u 'root@root.com:Root!1234' -X POST -F "fileContent=@internal/resources/flow.py" "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/files?path=/flow.py" > /dev/null
 curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string"

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -44,7 +44,7 @@ echo "start Kestra"
 docker compose -f docker-compose-ci.yml logs kestra;
 
 echo "inject test data in Vault"
-echo "\echo 'path \"*\" {capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"]}' | vault policy write admins -" | docker exec --interactive terraform-provider-kestra-vault-1 sh -
+echo "echo 'path \"*\" {capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"]}' | vault policy write admins -" | docker exec --interactive terraform-provider-kestra-vault-1 sh -
 docker compose -f docker-compose-ci.yml exec vault vault auth enable userpass
 docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/users/john \
     password=foo \

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -1,0 +1,39 @@
+echo "initializing test environment with docker compose"
+
+docker compose -f docker-compose-ci.yml up elasticsearch kafka vault -d --wait || {
+   echo "db Docker Compose failed. Dumping logs:";
+   docker-compose -f docker-compose-ci.yml logs;
+   exit 1;
+}
+docker compose -f docker-compose-ci.yml up kestra -d --wait || {
+   echo "kestra Docker Compose failed. Dumping logs:";
+   docker compose -f docker-compose-ci.yml logs kestra;
+   exit 1;
+}
+sleep 10
+docker compose -f docker-compose-ci.yml logs kestra;
+
+echo "\echo 'path \"*\" {capabilities = [\"create\", \"read\", \"update\", \"delete\", \"list\", \"sudo\"]}' | vault policy write admins -" | docker exec --interactive terraform-provider-kestra-vault-1 sh -
+docker compose -f docker-compose-ci.yml exec vault vault auth enable userpass
+docker compose -f docker-compose-ci.yml exec vault vault write auth/userpass/users/john \
+    password=foo \
+    policies=admins \
+    token_period=1s
+
+curl --fail-with-body "127.27.27.27:9200"
+curl --fail-with-body -H "Content-Type: application/x-ndjson" -XPOST "127.27.27.27:9200/_bulk?pretty" --data-binary @.github/workflows/index.jsonl > /dev/null
+sleep 5
+
+#curl --fail-with-body -X POST "127.27.27.27:8080/api/v1/users"
+
+curl  --fail-with-body -H "Content-Type: multipart/form-data" -u 'root@root.com:Root!1234' -X POST -F "fileContent=@internal/resources/flow.py" "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/files?path=/flow.py" > /dev/null
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '"stringValue"' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/string"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/int"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '1.5' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/double"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'false' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/falseBoolean"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'true' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/trueBoolean"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01T03:02:01Z' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/dateTime"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d '2022-05-01' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/date"
+curl  --fail-with-body -H "Content-Type: text/plain" -u 'root@root.com:Root!1234' -X PUT -d 'P3DT3H2M1S' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/duration"
+curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '{"some":"value","in":"object"}' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/object"
+curl  --fail-with-body -H "Content-Type: application/json" -u 'root@root.com:Root!1234' -X PUT -d '[{"some":"value","in":"object"},{"yet":"another","array":"object"}]' "127.27.27.27:8080/api/v1/main/namespaces/io.kestra.terraform.data/kv/array"

--- a/init-tests-env.sh
+++ b/init-tests-env.sh
@@ -31,7 +31,7 @@ echo "initializing test environment with docker compose"
 
 docker compose -f docker-compose-ci.yml up elasticsearch kafka vault -d --wait || {
    echo "db Docker Compose failed. Dumping logs:";
-   docker-compose -f docker-compose-ci.yml logs;
+   docker compose -f docker-compose-ci.yml logs;
    exit 1;
 }
 docker compose -f docker-compose-ci.yml up kestra -d --wait || {

--- a/internal/provider/data_source_service_account.go
+++ b/internal/provider/data_source_service_account.go
@@ -20,7 +20,7 @@ func dataSourceServiceAccount() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"username": {
+			"name": {
 				Description: "The service account name.",
 				Type:        schema.TypeString,
 				Computed:    true,

--- a/internal/provider/data_source_user_api_tokens.go
+++ b/internal/provider/data_source_user_api_tokens.go
@@ -87,8 +87,9 @@ func dataSourceUserApiTokensRead(ctx context.Context, d *schema.ResourceData, me
 	var diags diag.Diagnostics
 
 	id := d.Get("user_id").(string)
+	tenantId := c.TenantId
 
-	r, reqErr := c.request("GET", fmt.Sprintf("%s/users/%s/api-tokens", apiRoot(nil), id), nil)
+	r, reqErr := c.request("GET", fmt.Sprintf("%s/users/%s/api-tokens", apiRoot(tenantId), id), nil)
 	if reqErr != nil {
 		return diag.FromErr(reqErr.Err)
 	}

--- a/internal/provider/data_source_worker_group.go
+++ b/internal/provider/data_source_worker_group.go
@@ -1,10 +1,6 @@
 package provider
 
 import (
-	"context"
-	"fmt"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -37,24 +33,4 @@ func dataSourceWorkerGroup() *schema.Resource {
 			},
 		},
 	}
-}
-
-func dataSourceWorkerGroupRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	c := meta.(*Client)
-	var diags diag.Diagnostics
-
-	id := d.Get("id").(string)
-	tenantId := c.TenantId
-
-	r, reqErr := c.request("GET", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(tenantId), id), nil)
-	if reqErr != nil {
-		return diag.FromErr(reqErr.Err)
-	}
-
-	errs := workerGroupApiToSchema(r.(map[string]interface{}), d)
-	if errs != nil {
-		return errs
-	}
-
-	return diags
 }

--- a/internal/provider/data_source_worker_group_test.go
+++ b/internal/provider/data_source_worker_group_test.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+)
+
+func TestAccDataSourceWorkerGroup(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		ProviderFactories: providerFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccDataSourceWorkerGroup("1RgkLgU0oUXndtPswzaFku", "WorkerGroupKey-1"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestMatchResourceAttr(
+						"data.kestra_worker_group.new", "id", regexp.MustCompile("1RgkLgU0oUXndtPswzaFku"),
+					),
+					resource.TestMatchResourceAttr(
+						"data.kestra_worker_group.new", "key", regexp.MustCompile("WorkerGroupKey-1"),
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceWorkerGroup(id string, key string) string {
+	return fmt.Sprintf(
+		`
+        data "kestra_worker_group" "new" {
+            id = "%s"
+            key = "%s"
+        }`,
+		id,
+		key,
+	)
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -39,7 +39,7 @@ func New(version string, tenant *string) func() *schema.Provider {
 					Type:        schema.TypeString,
 					Optional:    true,
 					Description: "The tenant id (EE)",
-					DefaultFunc: schema.EnvDefaultFunc("KESTRA_TENANT_ID", ""),
+					DefaultFunc: schema.EnvDefaultFunc("KESTRA_TENANT_ID", "main"),
 				},
 				"username": &schema.Schema{
 					Type:        schema.TypeString,
@@ -133,13 +133,7 @@ func New(version string, tenant *string) func() *schema.Provider {
 			apiToken := d.Get("api_token").(string)
 			extraHeaders := d.Get("extra_headers")
 			keepOriginalSource := d.Get("keep_original_source").(bool)
-
-			tenantId := ""
-			if tenant != nil {
-				tenantId = *tenant
-			} else if d.Get("tenant_id") != nil {
-				tenantId = d.Get("tenant_id").(string)
-			}
+			tenantId := d.Get("tenant_id").(string)
 
 			var diags diag.Diagnostics
 
@@ -239,6 +233,5 @@ func apiRoot(tenantId *string) string {
 	if tenantId == nil || *tenantId == "" {
 		return "/api/v1"
 	}
-
 	return fmt.Sprintf("/api/v1/%s", *tenantId)
 }

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -133,7 +133,13 @@ func New(version string, tenant *string) func() *schema.Provider {
 			apiToken := d.Get("api_token").(string)
 			extraHeaders := d.Get("extra_headers")
 			keepOriginalSource := d.Get("keep_original_source").(bool)
-			tenantId := d.Get("tenant_id").(string)
+
+			tenantId := ""
+			if tenant != nil {
+				tenantId = *tenant
+			} else if d.Get("tenant_id") != nil {
+				tenantId = d.Get("tenant_id").(string)
+			}
 
 			var diags diag.Diagnostics
 

--- a/internal/provider/resource_binding_test.go
+++ b/internal/provider/resource_binding_test.go
@@ -39,7 +39,7 @@ func TestAccBinding(t *testing.T) {
 						"kestra_binding.new", "external_id", "john",
 					),
 					resource.TestCheckResourceAttr(
-						"kestra_binding.new", "role_id", "launcher_default",
+						"kestra_binding.new", "role_id", "launcher_main",
 					),
 				),
 			},

--- a/internal/provider/resource_binding_test.go
+++ b/internal/provider/resource_binding_test.go
@@ -30,7 +30,7 @@ func TestAccBinding(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceBinding("USER", "john", "launcher_default", "", "new"),
+				Config: testAccResourceBinding("USER", "john", "launcher_main", "", "new"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"kestra_binding.new", "type", "USER",

--- a/internal/provider/resource_binding_test.go
+++ b/internal/provider/resource_binding_test.go
@@ -13,7 +13,7 @@ func TestAccBinding(t *testing.T) {
 		ProviderFactories: providerFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceBinding("GROUP", "admin", "admin_default", "namespace = \"io.kestra.terraform.data\"", "new"),
+				Config: testAccResourceBinding("GROUP", "admin", "admin_main", "namespace = \"io.kestra.terraform.data\"", "new"),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
 						"kestra_binding.new", "type", "GROUP",
@@ -22,7 +22,7 @@ func TestAccBinding(t *testing.T) {
 						"kestra_binding.new", "external_id", "admin",
 					),
 					resource.TestCheckResourceAttr(
-						"kestra_binding.new", "role_id", "admin_default",
+						"kestra_binding.new", "role_id", "admin_main",
 					),
 					resource.TestCheckResourceAttr(
 						"kestra_binding.new", "namespace", "io.kestra.terraform.data",

--- a/internal/provider/resource_kv_test.go
+++ b/internal/provider/resource_kv_test.go
@@ -185,8 +185,10 @@ func TestAccKv(t *testing.T) {
 			urlEnv := strings.TrimRight(os.Getenv("KESTRA_URL"), "/")
 			usernameEnv := os.Getenv("KESTRA_USERNAME")
 			passwordEnv := os.Getenv("KESTRA_PASSWORD")
-			c, _ := NewClient(urlEnv, 10, &usernameEnv, &passwordEnv, nil, nil, nil, nil, nil)
-			url := c.Url + fmt.Sprintf("%s/namespaces/io.kestra.terraform/kv/string", apiRoot(nil))
+			defaultMainTenantId := "main"
+
+			c, _ := NewClient(urlEnv, 10, &usernameEnv, &passwordEnv, nil, nil, nil, &defaultMainTenantId, nil)
+			url := c.Url + fmt.Sprintf("%s/namespaces/io.kestra.terraform/kv/string", apiRoot(&defaultMainTenantId))
 			request, _ := http.NewRequest("GET", url, nil)
 			_, _, httpError := c.rawResponseRequest("GET", request)
 

--- a/internal/provider/resource_service_account.go
+++ b/internal/provider/resource_service_account.go
@@ -18,7 +18,7 @@ func resourceServiceAccount() *schema.Resource {
 		UpdateContext: resourceServiceAccountUpdate,
 		DeleteContext: resourceServiceAccountDelete,
 		Schema: map[string]*schema.Schema{
-			"username": {
+			"name": {
 				Description: "The service account name.",
 				Type:        schema.TypeString,
 				Required:    true,
@@ -108,7 +108,7 @@ func resourceServiceAccountUpdate(ctx context.Context, d *schema.ResourceData, m
 	c := meta.(*Client)
 	var diags diag.Diagnostics
 
-	if d.HasChanges("username", "description", "groups") {
+	if d.HasChanges("name", "description", "groups") {
 		body, err := serviceAccountSchemaToApi(d)
 		if err != nil {
 			return diag.FromErr(err)

--- a/internal/provider/resource_service_account.go
+++ b/internal/provider/resource_service_account.go
@@ -43,7 +43,8 @@ func resourceServiceAccount() *schema.Resource {
 						"tenant_id": {
 							Description: "The tenant id for this group.",
 							Type:        schema.TypeString,
-							Optional:    true,
+							Computed:    true, // currently this field is readonly in the API
+							ForceNew:    true,
 						},
 					},
 				},

--- a/internal/provider/resource_service_account_test.go
+++ b/internal/provider/resource_service_account_test.go
@@ -20,7 +20,7 @@ func TestAccServiceAccount(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"kestra_service_account.new", "username", "sa-1",
+						"kestra_service_account.new", "name", "sa-1",
 					),
 					resource.TestCheckResourceAttr(
 						"kestra_service_account.new", "description", "Test description",
@@ -37,7 +37,7 @@ func TestAccServiceAccount(t *testing.T) {
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(
-						"kestra_service_account.new", "username", "sa-2",
+						"kestra_service_account.new", "name", "sa-2",
 					),
 					resource.TestCheckResourceAttr(
 						"kestra_service_account.new", "description", "Test description",
@@ -72,7 +72,7 @@ func testAccResourceServiceAccount(name, group string) string {
         }
 
         resource "kestra_service_account" "new" {
-            username = "%s"
+            name = "%s"
 			description = "Test description"
 			%s
         }`,

--- a/internal/provider/resource_user_api_token_test.go
+++ b/internal/provider/resource_user_api_token_test.go
@@ -43,7 +43,7 @@ func testAccResourceUserApiToken() string {
 	return fmt.Sprintf(
 		`
         resource "kestra_service_account" "new" {
-            username = "test-service-account"
+            name = "test-service-account"
 			description = "Test description"
 		}
 

--- a/internal/provider/resource_worker_group.go
+++ b/internal/provider/resource_worker_group.go
@@ -52,9 +52,7 @@ func resourceWorkerGroupCreate(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	tenantId := c.TenantId
-
-	r, reqErr := c.request("POST", fmt.Sprintf("%s/cluster/workergroups", apiRoot(tenantId)), body)
+	r, reqErr := c.request("POST", fmt.Sprintf("%s/cluster/workergroups", apiRoot(nil)), body)
 	if reqErr != nil {
 		return diag.FromErr(reqErr.Err)
 	}
@@ -72,9 +70,8 @@ func resourceWorkerGroupRead(ctx context.Context, d *schema.ResourceData, meta i
 	var diags diag.Diagnostics
 
 	workerGroupId := d.Id()
-	tenantId := c.TenantId
 
-	r, reqErr := c.request("GET", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(tenantId), workerGroupId), nil)
+	r, reqErr := c.request("GET", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(nil), workerGroupId), nil)
 	if reqErr != nil {
 		if reqErr.StatusCode == http.StatusNotFound {
 			d.SetId("")
@@ -103,9 +100,8 @@ func resourceWorkerGroupUpdate(ctx context.Context, d *schema.ResourceData, meta
 		}
 
 		workerGroupId := d.Id()
-		tenantId := c.TenantId
 
-		r, reqErr := c.request("PUT", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(tenantId), workerGroupId), body)
+		r, reqErr := c.request("PUT", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(nil), workerGroupId), body)
 		if reqErr != nil {
 			return diag.FromErr(reqErr.Err)
 		}
@@ -126,9 +122,8 @@ func resourceWorkerGroupDelete(ctx context.Context, d *schema.ResourceData, meta
 	var diags diag.Diagnostics
 
 	workerGroupId := d.Id()
-	tenantId := c.TenantId
 
-	_, reqErr := c.request("DELETE", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(tenantId), workerGroupId), nil)
+	_, reqErr := c.request("DELETE", fmt.Sprintf("%s/cluster/workergroups/%s", apiRoot(nil), workerGroupId), nil)
 	if reqErr != nil {
 		return diag.FromErr(reqErr.Err)
 	}

--- a/internal/provider/utils_service_account.go
+++ b/internal/provider/utils_service_account.go
@@ -12,7 +12,7 @@ func serviceAccountSchemaToApi(d *schema.ResourceData) (map[string]interface{}, 
 		body["id"] = d.Id()
 	}
 
-	body["username"] = d.Get("username").(string)
+	body["name"] = d.Get("name").(string)
 	body["description"] = d.Get("description").(string)
 
 	// Convert group data from schema.Set to a slice of maps
@@ -39,7 +39,7 @@ func serviceAccountApiToSchema(r map[string]interface{}, d *schema.ResourceData)
 
 	d.SetId(r["id"].(string))
 
-	if err := d.Set("username", r["username"].(string)); err != nil {
+	if err := d.Set("name", r["name"].(string)); err != nil {
 		return diag.FromErr(err)
 	}
 


### PR DESCRIPTION
- tests were red
- i had to improve the test setup to be able to debug 0.23 compatibility issues
- there is one breaking change on service_account, and other internal changes related to tenants

maybe TODOS ?:

- [x] write in provider doc that 0.23.x terraform provider will only work for Kestra 0.23.x and above ?