### PR TITLE
ci: fail the build when generated docs are out of date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,35 @@ jobs:
         run: |
           go build -v .
 
+  docs:
+    name: Docs up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@v4
+        with:
+          terraform_wrapper: false
+
+      - name: Generate docs
+        run: go generate ./...
+
+      - name: Fail if docs are out of date
+        run: |
+          git add -N .
+          git diff --exit-code || {
+            echo "::error::Generated docs/examples are out of date. Run 'go generate' and commit the result."
+            exit 1
+          }
+
   test:
     name: Matrix Test
     needs: [build, list-versions]


### PR DESCRIPTION
- closes https://github.com/kestra-io/terraform-provider-kestra/issues/248