### PR TITLE
fix(kv): correct kestra_kv resource description

### DIFF
--- a/docs/resources/kv.md
+++ b/docs/resources/kv.md
@@ -3,12 +3,12 @@
 page_title: "kestra_kv Resource - terraform-provider-kestra"
 subcategory: ""
 description: |-
-  Manages a Kestra Namespace File.
+  Manages a Kestra Key-Value pair.
 ---
 
 # kestra_kv (Resource)
 
-Manages a Kestra Namespace File.
+Manages a Kestra Key-Value pair.
 
 
 

--- a/internal/provider/resource_kv.go
+++ b/internal/provider/resource_kv.go
@@ -13,7 +13,7 @@ import (
 
 func resourceKv() *schema.Resource {
 	return &schema.Resource{
-		Description: "Manages a Kestra Namespace File.",
+		Description: "Manages a Kestra Key-Value pair.",
 
 		CreateContext: resourceKvSet,
 		UpdateContext: resourceKvSet,


### PR DESCRIPTION
Backport of #278 to `releases/v1.3.x`.