### PR TITLE
chore(deps): bump go-sdk to v2.0.0-rc1

### DIFF
--- a/COMPATIBLE_KESTRA_VERSION.properties
+++ b/COMPATIBLE_KESTRA_VERSION.properties
@@ -1,1 +1,2 @@
 develop
+v2.0.0-rc1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/json-iterator/go v1.1.12
-	github.com/kestra-io/client-sdk/go-sdk v0.0.0-20260204105705-98782e1f7bed
+	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc1
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5Xum
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kestra-io/client-sdk/go-sdk v0.0.0-20260204105705-98782e1f7bed h1:/FWZXLUpLfpsCOCDtUTwL6x0Oml/iX4myeZ6EP8rPfQ=
-github.com/kestra-io/client-sdk/go-sdk v0.0.0-20260204105705-98782e1f7bed/go.mod h1:oglBUmW8SztlkA6PRAS1mPXWR+yUNHo2U0K4n327u9Y=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc1 h1:D49W2G86Bt62FQzBbqmtYkevVwHxqceJ0S2IH6EJGSo=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc1/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -205,8 +205,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
-github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tmaxmax/go-sse v0.11.0 h1:nogmJM6rJUoOLoAwEKeQe5XlVpt9l7N82SS1jI7lWFg=
 github.com/tmaxmax/go-sse v0.11.0/go.mod h1:u/2kZQR1tyngo1lKaNCj1mJmhXGZWS1Zs5yiSOD+Eg8=
 github.com/vmihailenco/msgpack v3.3.3+incompatible/go.mod h1:fy3FlTQTDXWkZ7Bh6AcGMlsjHatGryHQYUTf1ShIgkk=

--- a/internal/provider_v2/policy_api.go
+++ b/internal/provider_v2/policy_api.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"reflect"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/kestra-io/terraform-provider-kestra/internal/provider_v2/sdk_client"
 	// yaml.v3 follows YAML 1.2: an unquoted `on:` key — used by every policy rule — stays
 	// a string, while yaml.v2 (YAML 1.1) would resolve it to a boolean key.

--- a/internal/provider_v2/provider.go
+++ b/internal/provider_v2/provider.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"github.com/kestra-io/terraform-provider-kestra/internal/provider_v2/sdk_client"
 )
 

--- a/internal/provider_v2/sdk_client/raw_request.go
+++ b/internal/provider_v2/sdk_client/raw_request.go
@@ -8,7 +8,7 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 )
 
 func RawRequest(ctx context.Context, c *kestra_api_client.APIClient, method, relPath string, body interface{}) (map[string]interface{}, int, error) {

--- a/internal/provider_v2/sdk_client/sdk_client.go
+++ b/internal/provider_v2/sdk_client/sdk_client.go
@@ -3,7 +3,7 @@ package sdk_client
 import (
 	"context"
 	"encoding/base64"
-	"github.com/kestra-io/client-sdk/go-sdk/kestra_api_client"
+	"github.com/kestra-io/client-sdk/go-sdk/v2/kestra_api_client"
 	"net/http"
 	"time"
 )


### PR DESCRIPTION
Bumps `github.com/kestra-io/client-sdk/go-sdk` from `v0.0.0-20260204105705-98782e1f7bed` to `v2.0.0-rc1`.

The v2 major version ships a `go.mod`, so the module path gains the `/v2` suffix. Import paths in `internal/provider_v2/` are updated accordingly.

No API breakage: `go build ./...` and `go vet ./...` are clean.

Acceptance tests against a live Kestra instance have not been run.