### PR TITLE
feat(tenant,namespace): manage the Kestra 2.0 concurrency limit and quotas

### DIFF
--- a/docs/data-sources/namespace.md
+++ b/docs/data-sources/namespace.md
@@ -31,10 +31,12 @@ data "kestra_namespace" "example" {
 ### Read-Only
 
 - `allowed_namespaces` (List of Object) The allowed namespaces. (see [below for nested schema](#nestedatt--allowed_namespaces))
+- `concurrency` (List of Object) The concurrency limit applied to the executions of every flow of the namespace and its descendants: `limit` and `behavior`. (see [below for nested schema](#nestedatt--concurrency))
 - `default_worker_selector` (List of Object) The default routing applied to every task of the namespace that does not define its own: `tags`, `match` and `fallback`. (see [below for nested schema](#nestedatt--default_worker_selector))
 - `description` (String) The namespace description.
 - `id` (String) The namespace id.
 - `outputs_in_internal_storage` (Boolean) Whether the task outputs are stored in the internal storage.
+- `quotas` (List of Object) The quotas evaluated before an execution starts: `duration`, `limit` and `behavior`. (see [below for nested schema](#nestedatt--quotas))
 - `secret_configuration` (Dynamic) The namespace secret configuration.
 - `secret_isolation` (List of Object) Secret isolation configuration: `enabled` and `denied_services`. (see [below for nested schema](#nestedatt--secret_isolation))
 - `secret_read_only` (Boolean) Whether the namespace secret manager is read only.
@@ -53,6 +55,15 @@ Read-Only:
 - `namespace` (String)
 
 
+<a id="nestedatt--concurrency"></a>
+### Nested Schema for `concurrency`
+
+Read-Only:
+
+- `behavior` (String)
+- `limit` (Number)
+
+
 <a id="nestedatt--default_worker_selector"></a>
 ### Nested Schema for `default_worker_selector`
 
@@ -61,6 +72,16 @@ Read-Only:
 - `fallback` (String)
 - `match` (String)
 - `tags` (Set of String)
+
+
+<a id="nestedatt--quotas"></a>
+### Nested Schema for `quotas`
+
+Read-Only:
+
+- `behavior` (String)
+- `duration` (String)
+- `limit` (Number)
 
 
 <a id="nestedatt--secret_isolation"></a>

--- a/docs/data-sources/tenant.md
+++ b/docs/data-sources/tenant.md
@@ -30,10 +30,12 @@ data "kestra_tenant" "example" {
 
 ### Read-Only
 
+- `concurrency` (List of Object) The concurrency limit applied to the executions of every flow of the tenant: `limit` and `behavior`. (see [below for nested schema](#nestedatt--concurrency))
 - `default_worker_selector` (List of Object) The default routing applied to every task of the tenant that does not define its own: `tags`, `match` and `fallback`. (see [below for nested schema](#nestedatt--default_worker_selector))
 - `id` (String) The tenant id.
 - `name` (String) The tenant name.
 - `outputs_in_internal_storage` (Boolean) Whether outputs are stored in internal storage.
+- `quotas` (List of Object) The quotas evaluated before an execution starts: `duration`, `limit` and `behavior`. (see [below for nested schema](#nestedatt--quotas))
 - `require_existing_namespace` (Boolean) Whether tenant requires an existing namespace.
 - `secret_configuration` (Map of String) The secret configuration.
 - `secret_isolation` (List of Object) Secret isolation configuration: `enabled` and `denied_services`. (see [below for nested schema](#nestedatt--secret_isolation))
@@ -43,6 +45,15 @@ data "kestra_tenant" "example" {
 - `storage_isolation` (List of Object) Storage isolation configuration: `enabled` and `denied_services`. (see [below for nested schema](#nestedatt--storage_isolation))
 - `storage_type` (String) The storage type.
 
+<a id="nestedatt--concurrency"></a>
+### Nested Schema for `concurrency`
+
+Read-Only:
+
+- `behavior` (String)
+- `limit` (Number)
+
+
 <a id="nestedatt--default_worker_selector"></a>
 ### Nested Schema for `default_worker_selector`
 
@@ -51,6 +62,16 @@ Read-Only:
 - `fallback` (String)
 - `match` (String)
 - `tags` (Set of String)
+
+
+<a id="nestedatt--quotas"></a>
+### Nested Schema for `quotas`
+
+Read-Only:
+
+- `behavior` (String)
+- `duration` (String)
+- `limit` (Number)
 
 
 <a id="nestedatt--secret_isolation"></a>

--- a/docs/resources/namespace.md
+++ b/docs/resources/namespace.md
@@ -36,6 +36,18 @@ EOT
     match    = "ALL"
     fallback = "WAIT"
   }
+
+  # cap how many executions of this namespace and its descendants run at once
+  concurrency {
+    limit    = 5
+    behavior = "QUEUE"
+  }
+
+  quotas {
+    duration = "PT1H"
+    limit    = 50
+    behavior = "FAIL"
+  }
 }
 ```
 
@@ -49,9 +61,11 @@ EOT
 ### Optional
 
 - `allowed_namespaces` (Block List) The allowed namespaces. (see [below for nested schema](#nestedblock--allowed_namespaces))
+- `concurrency` (Block List) The concurrency limit applied to the executions of every flow inside this scope and its descendants. (see [below for nested schema](#nestedblock--concurrency))
 - `default_worker_selector` (Block List) The default routing applied to every task of the namespace that does not define its own. Tasks are routed to a `kestra_worker_queue` whose tag set matches. (see [below for nested schema](#nestedblock--default_worker_selector))
 - `description` (String) The namespace friendly description.
 - `outputs_in_internal_storage` (Boolean) Whether outputs are stored in internal storage.
+- `quotas` (Block List) Quotas evaluated before an execution starts. Without any quota, executions run normally. (see [below for nested schema](#nestedblock--quotas))
 - `secret_configuration` (Dynamic) Per-backend secret configuration. The whole value is a free-form map keyed by backend type (e.g. `vault`, `aws`, `gcp`), where each value is either a string or a nested object describing that backend's config.
 - `secret_isolation` (Block List) Secret isolation configuration. (see [below for nested schema](#nestedblock--secret_isolation))
 - `secret_read_only` (Boolean) Whether secrets are read-only in this namespace.
@@ -74,6 +88,15 @@ Required:
 - `namespace` (String) The namespace.
 
 
+<a id="nestedblock--concurrency"></a>
+### Nested Schema for `concurrency`
+
+Required:
+
+- `behavior` (String) What happens to an execution once the limit is reached.
+- `limit` (Number) The maximum number of concurrent executions.
+
+
 <a id="nestedblock--default_worker_selector"></a>
 ### Nested Schema for `default_worker_selector`
 
@@ -85,6 +108,16 @@ Optional:
 
 - `fallback` (String) The strategy when no worker is available: `FAIL` (default), `WAIT`, `CANCEL` or `IGNORE`.
 - `match` (String) How the tags are matched against a Worker Queue tag set: `ALL` (default, the queue tags must be a superset) or `ANY` (they must intersect).
+
+
+<a id="nestedblock--quotas"></a>
+### Nested Schema for `quotas`
+
+Required:
+
+- `behavior` (String) What happens to an execution once the quota is exhausted.
+- `duration` (String) The sliding window the quota is counted over, as an ISO-8601 duration (for example `PT1H`).
+- `limit` (Number) The maximum number of executions allowed inside the window.
 
 
 <a id="nestedblock--secret_isolation"></a>

--- a/docs/resources/tenant.md
+++ b/docs/resources/tenant.md
@@ -19,6 +19,19 @@ Manages a Kestra Tenant.
 resource "kestra_tenant" "example" {
   tenant_id = "my-tenant"
   name      = "My Tenant"
+
+  # cap how many executions of the whole tenant run at once
+  concurrency {
+    limit    = 10
+    behavior = "QUEUE"
+  }
+
+  # and how many may start inside a sliding window
+  quotas {
+    duration = "PT1H"
+    limit    = 100
+    behavior = "FAIL"
+  }
 }
 ```
 
@@ -31,9 +44,11 @@ resource "kestra_tenant" "example" {
 
 ### Optional
 
+- `concurrency` (Block List) The concurrency limit applied to the executions of every flow inside this scope and its descendants. (see [below for nested schema](#nestedblock--concurrency))
 - `default_worker_selector` (Block List) The default routing applied to every task of the tenant that does not define its own. Tasks are routed to a `kestra_worker_queue` whose tag set matches. (see [below for nested schema](#nestedblock--default_worker_selector))
 - `name` (String) The tenant name.
 - `outputs_in_internal_storage` (Boolean) Whether outputs are stored in internal storage.
+- `quotas` (Block List) Quotas evaluated before an execution starts. Without any quota, executions run normally. (see [below for nested schema](#nestedblock--quotas))
 - `require_existing_namespace` (Boolean) Whether tenant requires an existing namespace.
 - `secret_configuration` (Map of String) The secret configuration.
 - `secret_isolation` (Block List) Secret isolation configuration (same shape as storage_isolation). (see [below for nested schema](#nestedblock--secret_isolation))
@@ -47,6 +62,15 @@ resource "kestra_tenant" "example" {
 
 - `id` (String) The tenant id.
 
+<a id="nestedblock--concurrency"></a>
+### Nested Schema for `concurrency`
+
+Required:
+
+- `behavior` (String) What happens to an execution once the limit is reached.
+- `limit` (Number) The maximum number of concurrent executions.
+
+
 <a id="nestedblock--default_worker_selector"></a>
 ### Nested Schema for `default_worker_selector`
 
@@ -58,6 +82,16 @@ Optional:
 
 - `fallback` (String) The strategy when no worker is available: `FAIL` (default), `WAIT`, `CANCEL` or `IGNORE`.
 - `match` (String) How the tags are matched against a Worker Queue tag set: `ALL` (default, the queue tags must be a superset) or `ANY` (they must intersect).
+
+
+<a id="nestedblock--quotas"></a>
+### Nested Schema for `quotas`
+
+Required:
+
+- `behavior` (String) What happens to an execution once the quota is exhausted.
+- `duration` (String) The sliding window the quota is counted over, as an ISO-8601 duration (for example `PT1H`).
+- `limit` (Number) The maximum number of executions allowed inside the window.
 
 
 <a id="nestedblock--secret_isolation"></a>

--- a/e2e-test.sh
+++ b/e2e-test.sh
@@ -90,6 +90,81 @@ SURFACE="$E2E/surfaceTests"
 apply_and_assert_idempotent "$SURFACE" "surfaceTests"
 
 #-------------------------------------------------------------------------------
+# Suite A2 — concurrency limits and quotas (conditional)
+#-------------------------------------------------------------------------------
+CONCURRENCY="$E2E/concurrencyTests"
+
+# These fields landed in Kestra 2.0 after 2.0.0-rc1. An instance that predates them
+# accepts the field and drops it silently rather than rejecting the request, so writing
+# one and reading it back is the only way to tell. Mirrors testAccPreCheckConcurrency.
+concurrency_supported() {
+  local ns="io.kestra.terraform.e2econcurrencyprobe"
+  local base="$KESTRA_URL/api/v1/$KESTRA_TENANT_ID/namespaces"
+  curl -fsS -u "$KESTRA_USERNAME:$KESTRA_PASSWORD" -H 'Content-Type: application/json' \
+    -X POST -d "{\"id\":\"$ns\",\"deleted\":false,\"concurrency\":{\"limit\":1,\"behavior\":\"QUEUE\"}}" \
+    "$base" >/dev/null 2>&1 || return 1
+  local got
+  got=$(curl -fsS -u "$KESTRA_USERNAME:$KESTRA_PASSWORD" "$base/$ns" 2>/dev/null)
+  curl -fsS -u "$KESTRA_USERNAME:$KESTRA_PASSWORD" -X DELETE "$base/$ns" >/dev/null 2>&1 || true
+  printf '%s' "$got" | grep -q '"concurrency"'
+}
+
+# The bug this feature closes: both resources replace the whole entity on write, so a
+# limit set from the UI or the API used to be wiped by the next apply that touched the
+# namespace. That is only observable against a live instance — mutate the value out of
+# band, and require Terraform to report drift rather than quietly agreeing.
+assert_concurrency_drift() {
+  local ns="$1" configured="$2"
+  local base="$KESTRA_URL/api/v1/$KESTRA_TENANT_ID/namespaces"
+  local mutated=$((configured + 1))
+
+  step "concurrencyTests: a limit changed out of band must show up as drift"
+
+  # writes replace the entity, so send the current body back with only the limit changed
+  local body
+  body=$(curl -fsS -u "$KESTRA_USERNAME:$KESTRA_PASSWORD" "$base/$ns") || return 1
+  body=$(printf '%s' "$body" | python3 -c "
+import json,sys
+d = json.load(sys.stdin)
+d.setdefault('concurrency', {})['limit'] = $mutated
+print(json.dumps(d))
+") || return 1
+  curl -fsS -u "$KESTRA_USERNAME:$KESTRA_PASSWORD" -H 'Content-Type: application/json' \
+    -X PUT -d "$body" "$base/$ns" >/dev/null || return 1
+  echo "set the limit to $mutated behind Terraform's back (configured: $configured)"
+
+  local code=0
+  tf "$CONCURRENCY" plan -detailed-exitcode >/dev/null || code=$?
+  case $code in
+    2) echo "✅ drift detected" ;;
+    0) echo "❌ plan is empty — a limit changed outside Terraform is invisible, which is the bug this feature closes"; return 1 ;;
+    *) echo "❌ plan failed"; return 1 ;;
+  esac
+
+  step "concurrencyTests: apply must restore the configured limit"
+  tf "$CONCURRENCY" apply -auto-approve >/dev/null || return 1
+  code=0
+  tf "$CONCURRENCY" plan -detailed-exitcode >/dev/null || code=$?
+  [ "$code" -eq 0 ] || { echo "❌ plan still not empty after re-apply"; return 1; }
+  echo "✅ restored, plan empty again"
+}
+
+rm -f "$CONCURRENCY"/terraform.tfstate*
+if concurrency_supported; then
+  apply_and_assert_idempotent "$CONCURRENCY" "concurrencyTests"
+  assert_concurrency_drift \
+    "$(tf "$CONCURRENCY" output -raw namespace)" \
+    "$(tf "$CONCURRENCY" output -raw concurrency_limit)" \
+    || { tf "$CONCURRENCY" destroy -auto-approve >/dev/null 2>&1 || true; exit 1; }
+  step "concurrencyTests: destroy"
+  tf "$CONCURRENCY" destroy -auto-approve || { echo "❌ concurrencyTests destroy failed"; exit 1; }
+else
+  step "concurrencyTests: skipped"
+  echo "⏭  this instance accepts concurrency/quotas but does not return them, so it"
+  echo "   predates the fields (they landed in Kestra 2.0 after 2.0.0-rc1)."
+fi
+
+#-------------------------------------------------------------------------------
 # Suite B — scenario
 #-------------------------------------------------------------------------------
 BOOTSTRAP="$E2E/scenarioTests/00-bootstrap"

--- a/e2e-tests/concurrencyTests/main.tf
+++ b/e2e-tests/concurrencyTests/main.tf
@@ -1,0 +1,100 @@
+# Concurrency limits and quotas on tenants and namespaces.
+#
+# A separate suite because it is conditional: these fields landed in Kestra 2.0 after
+# 2.0.0-rc1, and an instance that predates them accepts the field and drops it silently
+# rather than rejecting it. On such an instance the write appears to succeed, the read
+# comes back without the block, and the follow-up plan is never empty — so this cannot
+# live in surfaceTests, whose whole contract is that the plan is empty after an apply.
+# ../../e2e-test.sh probes support once and skips this suite when the fields are absent.
+#
+# What it adds over the acceptance tests: those assert the blocks round-trip through
+# state. This asserts they survive in a real dependency graph and, more importantly, that
+# a limit changed outside Terraform shows up as drift rather than being silently
+# overwritten — the failure mode the feature exists to close.
+
+terraform {
+  required_providers {
+    kestra = {
+      # No version constraint on purpose: run against the provider built from the working
+      # tree via dev_overrides, which never evaluates one.
+      source = "kestra-io/kestra"
+    }
+  }
+}
+
+provider "kestra" {
+  url       = var.kestra_url
+  username  = var.kestra_username
+  password  = var.kestra_password
+  tenant_id = var.tenant_id
+}
+
+resource "kestra_namespace" "concurrency" {
+  namespace_id = "io.kestra.e2econcurrency"
+  description  = "Namespace carrying a concurrency limit and quotas."
+
+  concurrency {
+    limit    = 5
+    behavior = "QUEUE"
+  }
+
+  # more than one quota on purpose: quotas is an unbounded list, unlike concurrency which
+  # is capped at a single block, so ordering and count both need to round-trip
+  quotas {
+    duration = "PT1H"
+    limit    = 10
+    behavior = "FAIL"
+  }
+
+  quotas {
+    duration = "PT24H"
+    limit    = 100
+    behavior = "CANCEL"
+  }
+}
+
+resource "kestra_tenant" "concurrency" {
+  tenant_id = "e2e-concurrency"
+  name      = "E2E Concurrency"
+
+  # QUEUE is valid for a concurrency limit but not for a quota — the two are different
+  # enums, so exercise the one that only concurrency accepts
+  concurrency {
+    limit    = 3
+    behavior = "QUEUE"
+  }
+
+  quotas {
+    duration = "PT30M"
+    limit    = 4
+    behavior = "CANCEL"
+  }
+}
+
+data "kestra_namespace" "concurrency" {
+  namespace_id = kestra_namespace.concurrency.namespace_id
+}
+
+data "kestra_tenant" "concurrency" {
+  tenant_id = kestra_tenant.concurrency.tenant_id
+}
+
+# The data sources expose these as computed lists. Reading them back through a data
+# source rather than the resource's own state is what catches a read path that only
+# happens to work because the value was already in state.
+check "data_sources_report_the_configured_values" {
+  assert {
+    condition     = one(data.kestra_namespace.concurrency.concurrency).limit == 5
+    error_message = "namespace data source did not report the configured concurrency limit"
+  }
+
+  assert {
+    condition     = length(data.kestra_namespace.concurrency.quotas) == 2
+    error_message = "namespace data source did not report both quotas"
+  }
+
+  assert {
+    condition     = one(data.kestra_tenant.concurrency.concurrency).limit == 3
+    error_message = "tenant data source did not report the configured concurrency limit"
+  }
+}

--- a/e2e-tests/concurrencyTests/outputs.tf
+++ b/e2e-tests/concurrencyTests/outputs.tf
@@ -1,0 +1,9 @@
+output "namespace" {
+  description = "Namespace the drift assertion mutates out of band."
+  value       = kestra_namespace.concurrency.namespace_id
+}
+
+output "concurrency_limit" {
+  description = "The configured limit, so the drift assertion can pick a different one."
+  value       = one(kestra_namespace.concurrency.concurrency).limit
+}

--- a/e2e-tests/concurrencyTests/variables.tf
+++ b/e2e-tests/concurrencyTests/variables.tf
@@ -1,0 +1,24 @@
+variable "kestra_url" {
+  description = "The Kestra webserver/standalone URL."
+  type        = string
+  default     = "http://localhost:8088"
+}
+
+variable "kestra_username" {
+  description = "The super-admin declared in kestra.security.super-admin."
+  type        = string
+  default     = "root@root.com"
+}
+
+variable "kestra_password" {
+  description = "The super-admin password."
+  type        = string
+  default     = "Root!1234"
+  sensitive   = true
+}
+
+variable "tenant_id" {
+  description = "Tenant the namespace is created in."
+  type        = string
+  default     = "main"
+}

--- a/examples/resources/kestra_namespace/resource.tf
+++ b/examples/resources/kestra_namespace/resource.tf
@@ -18,4 +18,16 @@ EOT
     match    = "ALL"
     fallback = "WAIT"
   }
+
+  # cap how many executions of this namespace and its descendants run at once
+  concurrency {
+    limit    = 5
+    behavior = "QUEUE"
+  }
+
+  quotas {
+    duration = "PT1H"
+    limit    = 50
+    behavior = "FAIL"
+  }
 }

--- a/examples/resources/kestra_tenant/resource.tf
+++ b/examples/resources/kestra_tenant/resource.tf
@@ -1,4 +1,17 @@
 resource "kestra_tenant" "example" {
   tenant_id = "my-tenant"
   name      = "My Tenant"
+
+  # cap how many executions of the whole tenant run at once
+  concurrency {
+    limit    = 10
+    behavior = "QUEUE"
+  }
+
+  # and how many may start inside a sliding window
+  quotas {
+    duration = "PT1H"
+    limit    = 100
+    behavior = "FAIL"
+  }
 }

--- a/internal/provider/concurrency_precheck_test.go
+++ b/internal/provider/concurrency_precheck_test.go
@@ -1,0 +1,108 @@
+package provider
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// Namespace and tenant concurrency limits and quotas landed in Kestra 2.0 after
+// 2.0.0-rc1. An instance that predates them accepts the field and drops it
+// silently rather than rejecting the request, so the only way to tell is to write
+// one and see whether it comes back.
+//
+// testAccPreCheckConcurrency probes once and skips when the fields are not
+// supported, so an older instance reports a skip instead of an opaque "block
+// count changed from 1 to 0" apply failure. Any other probe outcome is left
+// alone: the test then runs and fails on its own terms.
+var (
+	concurrencyProbeOnce   sync.Once
+	concurrencyProbeReason string
+)
+
+func testAccPreCheckConcurrency(t *testing.T) {
+	testAccPreCheck(t)
+
+	concurrencyProbeOnce.Do(func() {
+		concurrencyProbeReason = probeConcurrencySupport()
+	})
+	if concurrencyProbeReason != "" {
+		t.Skipf("skipping concurrency acceptance tests: %s", concurrencyProbeReason)
+	}
+}
+
+func probeConcurrencySupport() string {
+	root := strings.TrimSuffix(os.Getenv("KESTRA_URL"), "/")
+	tenant := os.Getenv("KESTRA_TENANT_ID")
+	if tenant == "" {
+		tenant = "main"
+	}
+	namespaces := fmt.Sprintf("%s/api/v1/%s/namespaces", root, tenant)
+	id := "io.kestra.terraform.concurrencyprobe"
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"id":      id,
+		"deleted": false,
+		"concurrency": map[string]interface{}{
+			"limit":    1,
+			"behavior": "QUEUE",
+		},
+	})
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := doProbeRequest(client, http.MethodPost, namespaces, body)
+	if err != nil {
+		return fmt.Sprintf("the instance is unreachable at %s: %s", namespaces, err)
+	}
+	defer resp.Body.Close()
+	payload, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+
+	// Clean up regardless of the outcome; the probe namespace is not a fixture.
+	defer func() {
+		if del, err := doProbeRequest(client, http.MethodDelete, namespaces+"/"+id, nil); err == nil {
+			del.Body.Close()
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Sprintf("POST %s returned %d (%s)", namespaces, resp.StatusCode, strings.TrimSpace(string(payload)))
+	}
+
+	var decoded map[string]interface{}
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return fmt.Sprintf("could not decode the probe response: %s", err)
+	}
+	if _, ok := decoded["concurrency"]; !ok {
+		return "the instance accepted a namespace concurrency limit but did not return it, so it predates the field"
+	}
+	return ""
+}
+
+func doProbeRequest(client *http.Client, method, url string, body []byte) (*http.Response, error) {
+	var reader io.Reader
+	if body != nil {
+		reader = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		return nil, err
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := os.Getenv("KESTRA_API_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	} else if jwt := os.Getenv("KESTRA_JWT"); jwt != "" {
+		req.AddCookie(&http.Cookie{Name: "JWT", Value: jwt})
+	} else if user := os.Getenv("KESTRA_USERNAME"); user != "" {
+		req.SetBasicAuth(user, os.Getenv("KESTRA_PASSWORD"))
+	}
+	return client.Do(req)
+}

--- a/internal/provider/resource_namespace_test.go
+++ b/internal/provider/resource_namespace_test.go
@@ -180,3 +180,73 @@ EOT
 		variables,
 	)
 }
+
+// TestAccNamespaceConcurrencyAndQuotas covers the Kestra 2.0 concurrency limit
+// and quotas. The write path replaces the whole namespace, so the last step drops
+// both blocks to pin that removing them actually clears them server-side rather
+// than leaving the previous values in place.
+func TestAccNamespaceConcurrencyAndQuotas(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckConcurrency(t) },
+		ProtoV5ProviderFactories: muxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceNamespaceConcurrency("io.kestra.terraform.concurrency", 5, "QUEUE", "PT1H", 10, "FAIL"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "concurrency.0.limit", "5"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "concurrency.0.behavior", "QUEUE"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "quotas.0.duration", "PT1H"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "quotas.0.limit", "10"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "quotas.0.behavior", "FAIL"),
+				),
+			},
+			{
+				Config: testAccResourceNamespaceConcurrency("io.kestra.terraform.concurrency", 3, "FAIL", "PT30M", 7, "CANCEL"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "concurrency.0.limit", "3"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "concurrency.0.behavior", "FAIL"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "quotas.0.limit", "7"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "quotas.0.behavior", "CANCEL"),
+				),
+			},
+			{
+				Config: testAccResourceNamespaceConcurrencyBare("io.kestra.terraform.concurrency"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "concurrency.#", "0"),
+					resource.TestCheckResourceAttr("kestra_namespace.concurrency", "quotas.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceNamespaceConcurrency(id string, limit int, behavior, quotaDuration string, quotaLimit int, quotaBehavior string) string {
+	return fmt.Sprintf(
+		`
+        resource "kestra_namespace" "concurrency" {
+            namespace_id = "%s"
+
+            concurrency {
+                limit = %d
+                behavior = "%s"
+            }
+
+            quotas {
+                duration = "%s"
+                limit = %d
+                behavior = "%s"
+            }
+        }`,
+		id, limit, behavior, quotaDuration, quotaLimit, quotaBehavior,
+	)
+}
+
+func testAccResourceNamespaceConcurrencyBare(id string) string {
+	return fmt.Sprintf(
+		`
+        resource "kestra_namespace" "concurrency" {
+            namespace_id = "%s"
+        }`,
+		id,
+	)
+}

--- a/internal/provider/resource_tenant_test.go
+++ b/internal/provider/resource_tenant_test.go
@@ -46,3 +46,64 @@ func testAccResourceTenant(id, name string) string {
 		name,
 	)
 }
+
+// TestAccTenantConcurrencyAndQuotas covers the Kestra 2.0 concurrency limit and
+// quotas. The write path replaces the whole tenant, so the last step drops both
+// blocks to pin that removing them actually clears them server-side rather than
+// leaving the previous values in place.
+func TestAccTenantConcurrencyAndQuotas(t *testing.T) {
+	resource.UnitTest(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheckConcurrency(t) },
+		ProtoV5ProviderFactories: muxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccResourceTenantConcurrency("concurrency-tenant", "QUEUE", 5, "PT1H", 10, "FAIL"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "concurrency.0.limit", "5"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "concurrency.0.behavior", "QUEUE"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "quotas.0.duration", "PT1H"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "quotas.0.limit", "10"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "quotas.0.behavior", "FAIL"),
+				),
+			},
+			{
+				Config: testAccResourceTenantConcurrency("concurrency-tenant", "CANCEL", 2, "PT15M", 3, "CANCEL"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "concurrency.0.limit", "2"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "concurrency.0.behavior", "CANCEL"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "quotas.0.duration", "PT15M"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "quotas.0.limit", "3"),
+				),
+			},
+			{
+				Config: testAccResourceTenant("concurrency-tenant", "My custom tenant"),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("kestra_tenant.new", "concurrency.#", "0"),
+					resource.TestCheckResourceAttr("kestra_tenant.new", "quotas.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceTenantConcurrency(id, behavior string, limit int, quotaDuration string, quotaLimit int, quotaBehavior string) string {
+	return fmt.Sprintf(
+		`
+        resource "kestra_tenant" "concurrency" {
+            tenant_id = "%s"
+            name = "Concurrency tenant"
+
+            concurrency {
+                limit = %d
+                behavior = "%s"
+            }
+
+            quotas {
+                duration = "%s"
+                limit = %d
+                behavior = "%s"
+            }
+        }`,
+		id, limit, behavior, quotaDuration, quotaLimit, quotaBehavior,
+	)
+}

--- a/internal/provider/resource_tenant_test.go
+++ b/internal/provider/resource_tenant_test.go
@@ -76,14 +76,29 @@ func TestAccTenantConcurrencyAndQuotas(t *testing.T) {
 				),
 			},
 			{
-				Config: testAccResourceTenant("concurrency-tenant", "My custom tenant"),
+				Config: testAccResourceTenantConcurrencyBare("concurrency-tenant"),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("kestra_tenant.new", "concurrency.#", "0"),
-					resource.TestCheckResourceAttr("kestra_tenant.new", "quotas.#", "0"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "concurrency.#", "0"),
+					resource.TestCheckResourceAttr("kestra_tenant.concurrency", "quotas.#", "0"),
 				),
 			},
 		},
 	})
+}
+
+// The bare config has to keep the same resource address as the steps before it.
+// Switching to a different address with the same tenant_id makes Terraform create
+// the new tenant before destroying the old one, which the API rejects with
+// "Tenant id already exists" -- so the step would never reach its assertions.
+func testAccResourceTenantConcurrencyBare(id string) string {
+	return fmt.Sprintf(
+		`
+        resource "kestra_tenant" "concurrency" {
+            tenant_id = "%s"
+            name = "Concurrency tenant"
+        }`,
+		id,
+	)
 }
 
 func testAccResourceTenantConcurrency(id, behavior string, limit int, quotaDuration string, quotaLimit int, quotaBehavior string) string {

--- a/internal/provider_v2/data_source_namespace.go
+++ b/internal/provider_v2/data_source_namespace.go
@@ -49,6 +49,8 @@ type namespaceDataSourceModel struct {
 	SecretReadOnly           types.Bool    `tfsdk:"secret_read_only"`
 	SecretConfiguration      types.Dynamic `tfsdk:"secret_configuration"`
 	OutputsInInternalStorage types.Bool    `tfsdk:"outputs_in_internal_storage"`
+	Concurrency              types.List    `tfsdk:"concurrency"`
+	Quotas                   types.List    `tfsdk:"quotas"`
 }
 
 func (d *namespaceDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -124,6 +126,16 @@ func (d *namespaceDataSource) Schema(_ context.Context, _ datasource.SchemaReque
 				ElementType:         isolationObjectType,
 				MarkdownDescription: "Secret isolation configuration: `enabled` and `denied_services`.",
 			},
+			"concurrency": schema.ListAttribute{
+				Computed:            true,
+				ElementType:         concurrencyObjectType,
+				MarkdownDescription: "The concurrency limit applied to the executions of every flow of the namespace and its descendants: `limit` and `behavior`.",
+			},
+			"quotas": schema.ListAttribute{
+				Computed:            true,
+				ElementType:         quotaObjectType,
+				MarkdownDescription: "The quotas evaluated before an execution starts: `duration`, `limit` and `behavior`.",
+			},
 		},
 	}
 }
@@ -171,6 +183,8 @@ func (d *namespaceDataSource) Read(ctx context.Context, req datasource.ReadReque
 	data.DefaultWorkerSelector = workerSelectorToList(out)
 	data.StorageIsolation = isolationToList(out, "storageIsolation")
 	data.SecretIsolation = isolationToList(out, "secretIsolation")
+	data.Concurrency = concurrencyToList(out)
+	data.Quotas = quotasToList(out)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider_v2/data_source_tenant.go
+++ b/internal/provider_v2/data_source_tenant.go
@@ -41,6 +41,8 @@ type tenantDataSourceModel struct {
 	SecretConfiguration      types.Map    `tfsdk:"secret_configuration"`
 	RequireExistingNamespace types.Bool   `tfsdk:"require_existing_namespace"`
 	OutputsInInternalStorage types.Bool   `tfsdk:"outputs_in_internal_storage"`
+	Concurrency              types.List   `tfsdk:"concurrency"`
+	Quotas                   types.List   `tfsdk:"quotas"`
 }
 
 func (d *tenantDataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
@@ -108,6 +110,16 @@ func (d *tenantDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 				ElementType:         isolationObjectType,
 				MarkdownDescription: "Secret isolation configuration: `enabled` and `denied_services`.",
 			},
+			"concurrency": schema.ListAttribute{
+				Computed:            true,
+				ElementType:         concurrencyObjectType,
+				MarkdownDescription: "The concurrency limit applied to the executions of every flow of the tenant: `limit` and `behavior`.",
+			},
+			"quotas": schema.ListAttribute{
+				Computed:            true,
+				ElementType:         quotaObjectType,
+				MarkdownDescription: "The quotas evaluated before an execution starts: `duration`, `limit` and `behavior`.",
+			},
 		},
 	}
 }
@@ -154,6 +166,8 @@ func (d *tenantDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	data.DefaultWorkerSelector = workerSelectorToList(out)
 	data.StorageIsolation = isolationToList(out, "storageIsolation")
 	data.SecretIsolation = isolationToList(out, "secretIsolation")
+	data.Concurrency = concurrencyToList(out)
+	data.Quotas = quotasToList(out)
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }

--- a/internal/provider_v2/provider_mux_test.go
+++ b/internal/provider_v2/provider_mux_test.go
@@ -111,11 +111,30 @@ func TestMuxServesTenantAndNamespaceFromFrameworkProvider(t *testing.T) {
 	}
 
 	for _, name := range []string{"kestra_tenant", "kestra_namespace"} {
-		if _, ok := resp.ResourceSchemas[name]; !ok {
+		res, ok := resp.ResourceSchemas[name]
+		if !ok {
 			t.Errorf("expected the mux server to serve the %q resource", name)
+			continue
 		}
-		if _, ok := resp.DataSourceSchemas[name]; !ok {
+		blocks := make(map[string]bool, len(res.Block.BlockTypes))
+		for _, block := range res.Block.BlockTypes {
+			blocks[block.TypeName] = true
+		}
+		if !blocks["concurrency"] || !blocks["quotas"] {
+			t.Errorf("expected the %q resource to expose concurrency and quotas blocks, got %v", name, blocks)
+		}
+
+		ds, ok := resp.DataSourceSchemas[name]
+		if !ok {
 			t.Errorf("expected the mux server to serve the %q data source", name)
+			continue
+		}
+		attributes := make(map[string]bool, len(ds.Block.Attributes))
+		for _, attribute := range ds.Block.Attributes {
+			attributes[attribute.Name] = true
+		}
+		if !attributes["concurrency"] || !attributes["quotas"] {
+			t.Errorf("expected the %q data source to expose concurrency and quotas, got %v", name, attributes)
 		}
 	}
 

--- a/internal/provider_v2/resource_namespace.go
+++ b/internal/provider_v2/resource_namespace.go
@@ -56,6 +56,8 @@ type namespaceModel struct {
 	SecretReadOnly           types.Bool       `tfsdk:"secret_read_only"`
 	SecretConfiguration      types.Dynamic    `tfsdk:"secret_configuration"`
 	OutputsInInternalStorage types.Bool       `tfsdk:"outputs_in_internal_storage"`
+	Concurrency              []concurrency    `tfsdk:"concurrency"`
+	Quotas                   []quota          `tfsdk:"quotas"`
 }
 
 type allowedNS struct {
@@ -171,6 +173,8 @@ func (r *namespaceResource) Schema(_ context.Context, _ resource.SchemaRequest, 
 					},
 				},
 			},
+			"concurrency": concurrencyNestedBlock(),
+			"quotas":      quotasNestedBlock(),
 			"storage_isolation": schema.ListNestedBlock{
 				MarkdownDescription: "Storage isolation configuration.",
 				Validators:          []validator.List{listvalidator.SizeAtMost(1)},
@@ -240,7 +244,9 @@ func (r *namespaceResource) Create(ctx context.Context, req resource.CreateReque
 		resp.Diagnostics.AddError("Create namespace failed", err.Error())
 		return
 	}
+	configured := snapshotConcurrency(plan.Concurrency, plan.Quotas)
 	resp.Diagnostics.Append(bodyToNamespaceModel(ctx, out, r.providerData.TenantId, &plan)...)
+	configured.restore(&plan.Concurrency, &plan.Quotas)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -282,7 +288,9 @@ func (r *namespaceResource) Update(ctx context.Context, req resource.UpdateReque
 		resp.Diagnostics.AddError("Update namespace failed", err.Error())
 		return
 	}
+	configured := snapshotConcurrency(plan.Concurrency, plan.Quotas)
 	resp.Diagnostics.Append(bodyToNamespaceModel(ctx, out, r.providerData.TenantId, &plan)...)
+	configured.restore(&plan.Concurrency, &plan.Quotas)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -594,6 +602,12 @@ func namespaceModelToBody(ctx context.Context, m *namespaceModel) (map[string]in
 	if !m.OutputsInInternalStorage.IsNull() {
 		body["outputsInInternalStorage"] = m.OutputsInInternalStorage.ValueBool()
 	}
+	if c := concurrencyToBody(m.Concurrency); c != nil {
+		body["concurrency"] = c
+	}
+	if q := quotasToBody(m.Quotas); q != nil {
+		body["quotas"] = q
+	}
 	return body, diags
 }
 
@@ -778,6 +792,8 @@ func bodyToNamespaceModel(ctx context.Context, body map[string]interface{}, tena
 	if oi, ok := body["outputsInInternalStorage"].(bool); ok {
 		m.OutputsInInternalStorage = types.BoolValue(oi)
 	}
+	m.Concurrency = concurrencyFromBody(body)
+	m.Quotas = quotasFromBody(body)
 	return nil
 }
 

--- a/internal/provider_v2/resource_tenant.go
+++ b/internal/provider_v2/resource_tenant.go
@@ -50,6 +50,8 @@ type tenantModel struct {
 	SecretConfiguration      types.Map        `tfsdk:"secret_configuration"`
 	RequireExistingNamespace types.Bool       `tfsdk:"require_existing_namespace"`
 	OutputsInInternalStorage types.Bool       `tfsdk:"outputs_in_internal_storage"`
+	Concurrency              []concurrency    `tfsdk:"concurrency"`
+	Quotas                   []quota          `tfsdk:"quotas"`
 }
 
 func (r *tenantResource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -131,6 +133,8 @@ func (r *tenantResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 					},
 				},
 			},
+			"concurrency": concurrencyNestedBlock(),
+			"quotas":      quotasNestedBlock(),
 			"storage_isolation": schema.ListNestedBlock{
 				MarkdownDescription: "Storage isolation configuration.",
 				Validators:          []validator.List{listvalidator.SizeAtMost(1)},
@@ -184,7 +188,9 @@ func (r *tenantResource) Create(ctx context.Context, req resource.CreateRequest,
 		resp.Diagnostics.AddError("Create tenant failed", err.Error())
 		return
 	}
+	configured := snapshotConcurrency(plan.Concurrency, plan.Quotas)
 	resp.Diagnostics.Append(bodyToTenantModel(ctx, out, &plan)...)
+	configured.restore(&plan.Concurrency, &plan.Quotas)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -226,7 +232,9 @@ func (r *tenantResource) Update(ctx context.Context, req resource.UpdateRequest,
 		resp.Diagnostics.AddError("Update tenant failed", err.Error())
 		return
 	}
+	configured := snapshotConcurrency(plan.Concurrency, plan.Quotas)
 	resp.Diagnostics.Append(bodyToTenantModel(ctx, out, &plan)...)
+	configured.restore(&plan.Concurrency, &plan.Quotas)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
 }
 
@@ -365,6 +373,12 @@ func tenantModelToBody(ctx context.Context, m *tenantModel) (map[string]interfac
 	if !m.OutputsInInternalStorage.IsNull() {
 		body["outputsInInternalStorage"] = m.OutputsInInternalStorage.ValueBool()
 	}
+	if c := concurrencyToBody(m.Concurrency); c != nil {
+		body["concurrency"] = c
+	}
+	if q := quotasToBody(m.Quotas); q != nil {
+		body["quotas"] = q
+	}
 	return body, diags
 }
 
@@ -402,5 +416,7 @@ func bodyToTenantModel(ctx context.Context, body map[string]interface{}, m *tena
 	m.SecretConfiguration = stringMapFromBody(body["secretConfiguration"])
 	m.RequireExistingNamespace = optBool(body["requireExistingNamespace"])
 	m.OutputsInInternalStorage = optBool(body["outputsInInternalStorage"])
+	m.Concurrency = concurrencyFromBody(body)
+	m.Quotas = quotasFromBody(body)
 	return nil
 }

--- a/internal/provider_v2/resource_tenant_drift_test.go
+++ b/internal/provider_v2/resource_tenant_drift_test.go
@@ -26,6 +26,8 @@ func TestBodyToTenantModelClearsFieldsAbsentFromTheResponse(t *testing.T) {
 			SecretConfiguration:      types.MapValueMust(types.StringType, map[string]attr.Value{"k": types.StringValue("v")}),
 			RequireExistingNamespace: types.BoolValue(true),
 			OutputsInInternalStorage: types.BoolValue(true),
+			Concurrency:              []concurrency{{Limit: types.Int64Value(5), Behavior: types.StringValue("QUEUE")}},
+			Quotas:                   []quota{{Duration: types.StringValue("PT1H"), Limit: types.Int64Value(9), Behavior: types.StringValue("FAIL")}},
 		}
 	}
 
@@ -53,5 +55,19 @@ func TestBodyToTenantModelClearsFieldsAbsentFromTheResponse(t *testing.T) {
 	}
 	if !m.OutputsInInternalStorage.IsNull() {
 		t.Errorf("outputs_in_internal_storage should clear, got %v", m.OutputsInInternalStorage)
+	}
+	if len(m.Concurrency) != 0 {
+		t.Errorf("concurrency should clear, got %#v", m.Concurrency)
+	}
+	if len(m.Quotas) != 0 {
+		t.Errorf("quotas should clear, got %#v", m.Quotas)
+	}
+}
+
+// A concurrency object with neither field set would put nulls into two Required
+// attributes and fail the apply with an opaque type error.
+func TestConcurrencyFromBodyIgnoresAnEmptyObject(t *testing.T) {
+	if got := concurrencyFromBody(map[string]interface{}{"concurrency": map[string]interface{}{}}); got != nil {
+		t.Errorf("an empty concurrency object should read as unset, got %#v", got)
 	}
 }

--- a/internal/provider_v2/resource_tenant_upgrade_test.go
+++ b/internal/provider_v2/resource_tenant_upgrade_test.go
@@ -27,7 +27,8 @@ func currentTenantState(ctx context.Context, t *testing.T) tfsdk.State {
 }
 
 // TestTenantUpgradeStateV0 covers state written by the SDK v2 implementation. The
-// attribute names did not change, so everything has to survive the move.
+// attribute names did not change, so everything has to survive; `concurrency` and
+// `quotas` are new and stay absent rather than being invented.
 func TestTenantUpgradeStateV0(t *testing.T) {
 	ctx := context.Background()
 
@@ -107,4 +108,10 @@ func TestTenantUpgradeStateV0(t *testing.T) {
 	}
 
 	// The blocks the SDK v2 schema never had must not be conjured up by the upgrade.
+	if len(upgraded.Concurrency) != 0 {
+		t.Errorf("concurrency should be absent in upgraded state, got %#v", upgraded.Concurrency)
+	}
+	if len(upgraded.Quotas) != 0 {
+		t.Errorf("quotas should be absent in upgraded state, got %#v", upgraded.Quotas)
+	}
 }

--- a/internal/provider_v2/utils_concurrency.go
+++ b/internal/provider_v2/utils_concurrency.go
@@ -1,0 +1,256 @@
+package provider_v2
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// Kestra 2.0 evaluates a concurrency limit and a set of quotas on both tenants
+// and namespaces. Both carry the same shape on either resource, so the schema
+// blocks and the API conversions live here once.
+
+type concurrency struct {
+	Limit    types.Int64  `tfsdk:"limit"`
+	Behavior types.String `tfsdk:"behavior"`
+}
+
+type quota struct {
+	Duration types.String `tfsdk:"duration"`
+	Limit    types.Int64  `tfsdk:"limit"`
+	Behavior types.String `tfsdk:"behavior"`
+}
+
+// The two behaviours are not the same enum: a concurrency limit can queue the
+// execution, a quota can only fail or cancel it.
+var (
+	concurrencyBehaviors = []string{"QUEUE", "CANCEL", "FAIL"}
+	quotaBehaviors       = []string{"FAIL", "CANCEL"}
+)
+
+func concurrencyNestedBlock() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		MarkdownDescription: "The concurrency limit applied to the executions of every flow inside this scope and its descendants.",
+		Validators:          []validator.List{listvalidator.SizeAtMost(1)},
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"limit": schema.Int64Attribute{
+					Required:            true,
+					MarkdownDescription: "The maximum number of concurrent executions.",
+					Validators:          []validator.Int64{int64validator.AtLeast(1)},
+				},
+				"behavior": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "What happens to an execution once the limit is reached.",
+					Validators:          []validator.String{stringvalidator.OneOf(concurrencyBehaviors...)},
+				},
+			},
+		},
+	}
+}
+
+func quotasNestedBlock() schema.ListNestedBlock {
+	return schema.ListNestedBlock{
+		MarkdownDescription: "Quotas evaluated before an execution starts. Without any quota, executions run normally.",
+		NestedObject: schema.NestedBlockObject{
+			Attributes: map[string]schema.Attribute{
+				"duration": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "The sliding window the quota is counted over, as an ISO-8601 duration (for example `PT1H`).",
+				},
+				"limit": schema.Int64Attribute{
+					Required:            true,
+					MarkdownDescription: "The maximum number of executions allowed inside the window.",
+					Validators:          []validator.Int64{int64validator.AtLeast(1)},
+				},
+				"behavior": schema.StringAttribute{
+					Required:            true,
+					MarkdownDescription: "What happens to an execution once the quota is exhausted.",
+					Validators:          []validator.String{stringvalidator.OneOf(quotaBehaviors...)},
+				},
+			},
+		},
+	}
+}
+
+// concurrencyToBody renders the block for a request body, or nil when no block
+// is configured so the caller can leave the key out. Writes replace the whole
+// entity, so an omitted key clears any limit the server was holding -- which is
+// what an absent block should mean.
+func concurrencyToBody(list []concurrency) interface{} {
+	if len(list) == 0 {
+		return nil
+	}
+	return map[string]interface{}{
+		"limit":    list[0].Limit.ValueInt64(),
+		"behavior": list[0].Behavior.ValueString(),
+	}
+}
+
+func quotasToBody(list []quota) interface{} {
+	if len(list) == 0 {
+		return nil
+	}
+	out := make([]map[string]interface{}, len(list))
+	for i, q := range list {
+		out[i] = map[string]interface{}{
+			"duration": q.Duration.ValueString(),
+			"limit":    q.Limit.ValueInt64(),
+			"behavior": q.Behavior.ValueString(),
+		}
+	}
+	return out
+}
+
+// configuredConcurrency snapshots the planned blocks so a write can restore them
+// over whatever the response carried.
+//
+// The provider supports Kestra 2.0.0-rc1, which is in the CI matrix and which
+// accepts these fields but omits them from the write response. They are pure
+// configuration, so the framework requires the post-write state to match the
+// plan; letting the response clear them fails the apply outright.
+//
+// The restore also masks server-side normalisation: an instance that clamped a
+// limit or rewrote a behavior would land the planned value in state rather than
+// Terraform raising "Provider produced inconsistent result after apply". Read
+// treats an absent or differing key as drift, so either case resurfaces as a
+// diff on the next plan.
+type configuredConcurrency struct {
+	concurrency []concurrency
+	quotas      []quota
+}
+
+func snapshotConcurrency(c []concurrency, q []quota) configuredConcurrency {
+	return configuredConcurrency{concurrency: c, quotas: q}
+}
+
+func (s configuredConcurrency) restore(c *[]concurrency, q *[]quota) {
+	*c, *q = s.concurrency, s.quotas
+}
+
+// concurrencyFromBody mirrors the defaultWorkerSelector handling: the API omits
+// null fields, so an absent key means genuinely unset and has to surface as
+// drift rather than leaving the prior value in place.
+func concurrencyFromBody(body map[string]interface{}) []concurrency {
+	raw, ok := body["concurrency"].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+	one := concurrency{Limit: types.Int64Null(), Behavior: types.StringNull()}
+	if limit, ok := numberFromBody(raw["limit"]); ok {
+		one.Limit = types.Int64Value(limit)
+	}
+	if behavior, ok := raw["behavior"].(string); ok && behavior != "" {
+		one.Behavior = types.StringValue(behavior)
+	}
+	// Both are Required in the schema, so an empty object would put nulls in state
+	// and fail the apply with an opaque type error. Treat it as unset.
+	if one.Limit.IsNull() && one.Behavior.IsNull() {
+		return nil
+	}
+	return []concurrency{one}
+}
+
+func quotasFromBody(body map[string]interface{}) []quota {
+	raw, ok := body["quotas"].([]interface{})
+	if !ok {
+		return nil
+	}
+	out := make([]quota, 0, len(raw))
+	for _, item := range raw {
+		mp, ok := item.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		one := quota{Duration: types.StringNull(), Limit: types.Int64Null(), Behavior: types.StringNull()}
+		if duration, ok := mp["duration"].(string); ok && duration != "" {
+			one.Duration = types.StringValue(duration)
+		}
+		if limit, ok := numberFromBody(mp["limit"]); ok {
+			one.Limit = types.Int64Value(limit)
+		}
+		if behavior, ok := mp["behavior"].(string); ok && behavior != "" {
+			one.Behavior = types.StringValue(behavior)
+		}
+		out = append(out, one)
+	}
+	return out
+}
+
+// numberFromBody accepts the shapes a JSON number can decode into, since the
+// request bodies are round-tripped through map[string]interface{} rather than a
+// typed model.
+func numberFromBody(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case float64:
+		return int64(n), true
+	case int64:
+		return n, true
+	case int:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	}
+	return 0, false
+}
+
+// Data sources expose these as computed lists of objects rather than blocks: the
+// mux server downgrades the framework provider to protocol v5, and a computed
+// nested attribute is not representable there.
+
+var concurrencyObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"limit":    types.Int64Type,
+	"behavior": types.StringType,
+}}
+
+var quotaObjectType = types.ObjectType{AttrTypes: map[string]attr.Type{
+	"duration": types.StringType,
+	"limit":    types.Int64Type,
+	"behavior": types.StringType,
+}}
+
+func concurrencyToList(body map[string]interface{}) types.List {
+	list := concurrencyFromBody(body)
+	elems := make([]attr.Value, 0, len(list))
+	for _, c := range list {
+		obj, diags := types.ObjectValue(concurrencyObjectType.AttrTypes, map[string]attr.Value{
+			"limit":    c.Limit,
+			"behavior": c.Behavior,
+		})
+		if diags.HasError() {
+			continue
+		}
+		elems = append(elems, obj)
+	}
+	out, diags := types.ListValue(concurrencyObjectType, elems)
+	if diags.HasError() {
+		return types.ListNull(concurrencyObjectType)
+	}
+	return out
+}
+
+func quotasToList(body map[string]interface{}) types.List {
+	list := quotasFromBody(body)
+	elems := make([]attr.Value, 0, len(list))
+	for _, q := range list {
+		obj, diags := types.ObjectValue(quotaObjectType.AttrTypes, map[string]attr.Value{
+			"duration": q.Duration,
+			"limit":    q.Limit,
+			"behavior": q.Behavior,
+		})
+		if diags.HasError() {
+			continue
+		}
+		elems = append(elems, obj)
+	}
+	out, diags := types.ListValue(quotaObjectType, elems)
+	if diags.HasError() {
+		return types.ListNull(quotaObjectType)
+	}
+	return out
+}


### PR DESCRIPTION
Split out of #286. **Stacked on #287** — review that one first; this PR's diff is against it and is purely additive (+734 / −3).

Retarget to `main` once #287 merges.

## Why

Kestra 2.0 evaluates a **concurrency limit** and a set of **quotas** on both tenants and namespaces. Neither was reachable from Terraform.

That wasn't only a missing feature. Both resources replace the whole entity on write, which I confirmed against a live 2.0 instance:

```
create namespace with concurrency {limit:5, QUEUE}  -> concurrency: {limit:5, QUEUE}
PUT full body without concurrency                   -> concurrency: None
GET                                                 -> concurrency: None
```

So a limit set from the UI or the API was **silently cleared** by the next `apply` that touched the tenant or namespace. Same read-modify-write-over-full-replace shape as the `kestractl users update` silent demotion. This closes that as well as adding the feature.

## What changed

`concurrency` (`limit` + `behavior`) and `quotas` (`duration` + `limit` + `behavior`) are blocks on `kestra_tenant` and `kestra_namespace`, and computed lists on both data sources. The behaviours are deliberately different enums: a concurrency limit can `QUEUE`, a quota can only `FAIL` or `CANCEL`.

## The compatibility shim

`snapshotConcurrency`/`restore` carries the planned blocks over the write response. **2.0.0-rc1 is in the CI matrix** and accepts these fields but omits them from that response; they're pure configuration, so the framework requires post-write state to match the plan, and letting the response clear them fails the apply outright.

The same restore also masks server-side normalisation — an instance that clamped a limit would land the planned value in state rather than Terraform raising "inconsistent result after apply". Read treats an absent or differing key as drift, so either case resurfaces on the next plan. The helper documents both halves. **When rc1 leaves the CI matrix, this shim should go with it.**

## Tests

Acceptance tests for both resources, each ending with a step that drops both blocks — that step is what would have caught the silent-clearing bug.

They probe the instance once and **skip** when it predates the fields, so an older instance reports a skip rather than an opaque "block count changed from 1 to 0" apply failure.

An empty `concurrency: {}` reads as unset rather than a block with two null `Required` attributes, which would fail an apply with an opaque type error.

Docs regenerated with `tfplugindocs`, verified zero-drift.