### PR TITLE
fix(ci): open a PR for docs sync instead of pushing to docs main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -50,14 +50,26 @@ jobs:
           mkdir -p ../../docs/content/docs/13.terraform/
           cp -R * ../../docs/content/docs/13.terraform/
 
-      - name: Push change to docs
-        uses: stefanzweifel/git-auto-commit-action@v7
+      - name: Generate docs app token
+        id: docs-app-token
+        uses: actions/create-github-app-token@v3
         with:
-          commit_message: "feat(docs): update terraform docs"
-          branch: main
-          file_pattern: 'content/docs/13.terraform/*'
-          repository: "docs"
-          pull_before_commit: true
+          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
+          owner: kestra-io
+          repositories: docs
+
+      - name: Open PR with docs change
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ steps.docs-app-token.outputs.token }}
+          path: docs
+          commit-message: "feat(docs): update terraform docs"
+          branch: "chore/terraform-docs-${{ github.ref_name }}"
+          base: main
+          add-paths: 'content/docs/13.terraform/*'
+          title: "feat(docs): update terraform docs (${{ github.ref_name }})"
+          body: "Automated docs update triggered by terraform-provider-kestra release ${{ github.ref_name }}."
 
       - name: Slack - Notify CI failure
         if: failure()

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,7 +54,7 @@ jobs:
         id: docs-app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.GH_BOT_APP_ID }}
+          client-id: ${{ secrets.GH_BOT_APP_ID }}
           private-key: ${{ secrets.GH_BOT_PRIVATE_KEY }}
           owner: kestra-io
           repositories: docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,16 +60,20 @@ jobs:
           repositories: docs
 
       - name: Open PR with docs change
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ steps.docs-app-token.outputs.token }}
-          path: docs
-          commit-message: "feat(docs): update terraform docs"
-          branch: "chore/terraform-docs-${{ github.ref_name }}"
-          base: main
-          add-paths: 'content/docs/13.terraform/*'
-          title: "feat(docs): update terraform docs (${{ github.ref_name }})"
-          body: "Automated docs update triggered by terraform-provider-kestra release ${{ github.ref_name }}."
+        env:
+          GH_TOKEN: ${{ steps.docs-app-token.outputs.token }}
+        run: |
+          cd docs
+          BRANCH="chore/terraform-docs-${{ github.ref_name }}"
+          git add content/docs/13.terraform/
+          git diff --cached --quiet && { echo "No docs changes, skipping."; exit 0; }
+          git checkout -b "$BRANCH"
+          git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
+            commit -m "feat(docs): update terraform docs"
+          git push -u origin "$BRANCH"
+          gh pr create --base main --head "$BRANCH" \
+            --title "feat(docs): update terraform docs (${{ github.ref_name }})" \
+            --body "Automated docs update triggered by terraform-provider-kestra release ${{ github.ref_name }}."
 
       - name: Slack - Notify CI failure
         if: failure()


### PR DESCRIPTION
## Summary
- kestra-io/docs main now requires PRs (branch ruleset), so the tag-triggered docs sync job's direct push via `git-auto-commit-action` fails with GH013.
- Mint a scoped GH App token for `kestra-io/docs` and use `peter-evans/create-pull-request` to push to a branch and open a PR against `main` instead.

## Test plan
- [ ] Push a tag / trigger `workflow_dispatch` on Docs workflow and confirm a PR is opened against kestra-io/docs main instead of a rejected direct push