### PR TITLE
chore(deps): bump go-sdk to v2.0.0-rc3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
 	github.com/json-iterator/go v1.1.12
-	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2
+	github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5Xum
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2 h1:Nsr5D1WmMh07Z8olfrGesBoswiEhChaDMg1L9kQi0+Y=
-github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc2/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3 h1:wWymwgqpnDlwpWurxmSUFbpMOh8wVhK9qQx+fU7xqSM=
+github.com/kestra-io/client-sdk/go-sdk/v2 v2.0.0-rc3/go.mod h1:ckpZC/7pTYvb7B2iLxY90UGKu374oBvDsGXJ8bWtlwk=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=


### PR DESCRIPTION
Bumps `client-sdk/go-sdk/v2` from `v2.0.0-rc2` to the published `v2.0.0-rc3`.

## Is anything needed for rc2 → rc3?

No. The diff is **purely additive**: 456 insertions, zero deletions, no signature changes. New surface is `TenantsAPI`, `QuotasAPI`, `TenantAccessAPI`, `CasesAPI`, their `KestraClient` accessors, plus `StreamAppEvents` and `ReplayExecutionWithInputs`.

The provider's SDK surface is deliberately tiny — `NewAPIClient`, `NewConfiguration`, `ServerConfiguration` and `APIClient`, used only as transport for `sdk_client.RawRequest` — and none of those changed. So this is a `go.mod`/`go.sum`-only change.

Worth noting for anyone reading the tenant/namespace concurrency and quota work: those resources go through `RawRequest`, not the typed SDK methods, so the new `TenantsAPI`/`QuotasAPI` bindings don't change how they behave here. They're available if we ever want to move those resources onto typed calls.

## Verification

- `go build ./... && go vet ./...` clean.
- Unit tests green: `internal/provider`, `internal/provider_v2` (including the tenant/namespace concurrency drift tests) and `internal/provider_v2/sdk_client`.
- The `TestAcc*` prechecks fail without `KESTRA_URL`, which is **pre-existing** — I confirmed they fail identically on unmodified `main` at rc2.
