### PR TITLE
test: target Kestra v2.0.0-rc13 in the acceptance matrix

### DIFF
--- a/COMPATIBLE_KESTRA_VERSION.properties
+++ b/COMPATIBLE_KESTRA_VERSION.properties
@@ -1,2 +1,2 @@
 develop
-v2.0.0-rc2
+v2.0.0-rc13

--- a/e2e-tests/scenarioTests/00-bootstrap/main.tf
+++ b/e2e-tests/scenarioTests/00-bootstrap/main.tf
@@ -148,6 +148,15 @@ resource "kestra_user" "app_user" {
   description = "Regular user. Permissions come from the group stage 10 puts it in."
 }
 
+# Since Kestra 2.0 tenant access is a prerequisite rather than something granted as a
+# side effect: stage 10 puts this user in a group, and that write resolves the user
+# through a tenant access check and 404s without this. Granted here, as root, rather
+# than in stage 10: the platform admin stage 10 authenticates as is not necessarily
+# permitted to hand out tenant access.
+resource "kestra_user_tenant_access" "app_user" {
+  user_id = kestra_user.app_user.id
+}
+
 resource "kestra_user_password" "app_user" {
   user_id  = kestra_user.app_user.id
   password = var.app_user_password

--- a/e2e-tests/scenarioTests/runtime/execution_test.go
+++ b/e2e-tests/scenarioTests/runtime/execution_test.go
@@ -14,7 +14,6 @@ type execution struct {
 	State struct {
 		Current string `json:"current"`
 	} `json:"state"`
-	Outputs     map[string]any `json:"outputs"`
 	TaskRunList []struct {
 		TaskID string `json:"taskId"`
 		State  struct {
@@ -56,13 +55,22 @@ func TestAppUserRunsFlowSuccessfully(t *testing.T) {
 			exec.ID, exec.State.Current, taskStates(exec), truncate(body))
 	}
 
+	// Flow-level outputs are fetched rather than read off the execution: Kestra 2.0.0-rc9
+	// moved them out of the execution into their own table, served from this endpoint, so
+	// the payload above no longer carries them. Reading them as the app user also needs
+	// EXECUTION ACCESS_OUTPUTS, which the launcher role grants.
+	outputs := decode[map[string]any](t, c.expectOK(t, request{
+		method: "GET",
+		path:   fmt.Sprintf("/outputs/executions/%s", exec.ID),
+	}), "execution outputs")
+
 	// Proves the input reached the flow (first half) and that the KV entry resolved
 	// (second half). A greeting sent the wrong way would silently fall back to the
 	// flow's default and show up here.
 	want := greeting + ":" + env(t, "KESTRA_E2E_KV_VALUE")
-	got, ok := exec.Outputs["result"].(string)
+	got, ok := outputs["result"].(string)
 	if !ok {
-		t.Fatalf("execution %s has no string output \"result\"; outputs=%v", exec.ID, exec.Outputs)
+		t.Fatalf("execution %s has no string output \"result\"; outputs=%v", exec.ID, outputs)
 	}
 	if got != want {
 		t.Errorf("flow output = %q, want %q — the input, the KV entry or both did not reach the flow", got, want)


### PR DESCRIPTION
Moves the acceptance matrix's release axis from `v2.0.0-rc2` to `v2.0.0-rc13`.

## Why

`COMPATIBLE_KESTRA_VERSION.properties` was pinned to rc2 — eleven RCs behind. That matters beyond staleness: tenant and namespace **concurrency limits and quotas landed in Kestra 2.0 after rc2**, and `e2e-tests/concurrencyTests` probes for the fields and skips the whole suite when the instance predates them.

So on the only non-`develop` leg, that suite was silently skipping. The drift assertion it exists for — a limit changed outside Terraform must show up as drift rather than being silently overwritten — was never enforced against a released version.

## Why rc13 specifically

rc13 is the current latest RC; its image publish completed successfully this morning. The shared publish workflow pushes every tag to `ghcr.io/kestra-io/kestra-ee` and the GCP registry in the same `build-push` step, so the tag CI pulls from ghcr is guaranteed present.

## Risk

Low, but worth stating plainly: these legs are hard failures (only `develop` is `continue-on-error`), so this makes the suite strictly stricter.

I checked the `develop` legs at **step** level rather than trusting the green job badge — `continue-on-error` would mask a failing step — and both `Terraform acceptance tests` and `Terraform E2E tests` genuinely report `success`. Since `develop` is ahead of rc13 and passes, rc13 is expected to pass too. CI on this PR is the real proof.

I verified the concurrency/quota behaviour by hand against a live rc12 instance earlier today (create, update, out-of-band drift, restore, destroy), so the suite this unlocks is known to pass on a late 2.0 RC.
