### PR TITLE
fix(ci): publish terraform docs into the website content collection

### DIFF
--- a/.github/scripts/docs-to-website.sh
+++ b/.github/scripts/docs-to-website.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Mirrors the tfplugindocs output into the kestra.io website docs collection.
+# Usage: docs-to-website.sh <provider-docs-dir> <website-terraform-docs-dir>
+set -euo pipefail
+
+SRC="${1:?provider docs dir required}"
+DEST="${2:?website terraform docs dir required}"
+
+# The transform runs from a temp copy, so both paths have to be absolute.
+SRC="$(cd "$SRC" && pwd)"
+mkdir -p "$DEST"
+DEST="$(cd "$DEST" && pwd)"
+
+FRONTMATTER='NR==1 && $0!="---" {exit} NR==1 {next} $0=="---" {exit} {print}'
+BODY='NR==1 {if ($0=="---") {fm=1; next} else {out=1}}
+      fm && !out {if ($0=="---") out=1; next}
+      out {print}'
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+cp -R "$SRC"/. "$WORK/"
+cd "$WORK"
+
+# The provider index page is published as the "configurations" guide.
+mkdir -p guides
+sed -Ei 's/page_title: "([^ ]+).*"/title: Provider configurations/' index.md
+sed -Ei 's/^# kestra Provider/# Provider configurations/' index.md
+mv index.md guides/configurations.md
+
+# Frontmatter: tfplugindocs pages are generated, so they are not editable on GitHub.
+find . -type f -name '*.md' -exec sed -i 's/subcategory: ""/editLink: false/g' {} +
+find data-sources resources -type f -name '*.md' \
+    -exec sed -Ei 's/page_title: "([^ ]+).*"/title: \1/' {} +
+find guides -type f -name '*.md' -exec sed -Ei 's/page_title: "([^"]+)"/title: \1/' {} +
+
+# Body: hcl highlighting, Astro alert directives, links to the website page layout.
+find . -type f -name '*.md' -exec sed -i \
+    -e 's/```terraform/```hcl/g' \
+    -e 's/^-> \(.*\)/:::alert{type="info"}\n\1\n:::/' \
+    -e 's/^~> \(.*\)/:::alert{type="warning"}\n\1\n:::/' \
+    -e 's/^!> \(.*\)/:::alert{type="danger"}\n\1\n:::/' \
+    -e 's#](\(\.\./[^)]*\)\.md)#](../\1/index.md)#g' \
+    -e 's#](\([A-Za-z0-9._-]*\)\.md)#](../\1/index.md)#g' \
+    {} +
+
+skipped=""
+while read -r file; do
+    page="${file#./}"
+    out="$DEST/${page%.md}/index.md"
+
+    # Guides are prose the website team edits in place; only publish new ones.
+    if [ -f "$out" ] && [ "${page%%/*}" = guides ]; then
+        skipped="$skipped $page"
+        continue
+    fi
+
+    # The website owns the frontmatter (titles, descriptions); only the body is mirrored.
+    if [ -f "$out" ]; then
+        frontmatter="$(awk "$FRONTMATTER" "$out")"
+    else
+        frontmatter="$(awk "$FRONTMATTER" "$file")"
+    fi
+
+    body="$(awk "$BODY" "$file" | awk '
+        /^```/ {fenced = !fenced}
+        # The website renders the H1 from frontmatter, so demote the generated one.
+        !fenced && !demoted && /^# / {
+            demoted = 1
+            title = substr($0, 3)
+            if (sub(/ \(Resource\)$/, "", title)) print "## Terraform Resource: " title
+            else if (sub(/ \(Data Source\)$/, "", title)) print "## Terraform Data Source: " title
+            else print "## " title
+            next
+        }
+        {print}
+    ' | sed -e 's/^## Example Usage$/## Example usage/' -e '/./,$!d')"
+
+    # The docs collection requires a title, and upstream guides do not always carry one.
+    if ! grep -q '^title:' <<<"$frontmatter"; then
+        heading="$(sed -n 's/^## //p' <<<"$body" | head -1)"
+        frontmatter="$(printf 'title: %s\n%s' "${heading:-$(basename "${page%.md}")}" "$frontmatter")"
+    fi
+
+    mkdir -p "$(dirname "$out")"
+    printf -- '---\n%s\n---\n\n%s\n' "$frontmatter" "$body" > "$out"
+done < <(find data-sources resources guides -type f -name '*.md' | sort)
+
+echo "Mirrored the provider docs into $DEST"
+[ -n "$skipped" ] && echo "Guides already on the website, left untouched:$skipped"
+exit 0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,25 +30,9 @@ jobs:
 
       - name: Transform docs for website
         run: |
-          cd terraform-provider-kestra/docs/
-          
-          find  -type f -name "*.md" -exec sed -i 's/subcategory: ""/editLink: false/g' {} +
-          find . -type f -name "*.md" -exec sed -i 's/```terraform/```hcl/g' {} +
-          
-          find data-sources -type f -name "*.md" -exec sed -Ei  's/page_title: "([^ ]+).*"/title: \1/g' {} +
-          find resources -type f -name "*.md" -exec sed -Ei  's/page_title: "([^ ]+).*"/title: \1/g' {} +
-          find guides -type f -name "*.md" -exec sed -Ei  's/page_title: "([^"]+)"/title: \1/g' {} +
-          
-          find . -type f -name "*.md" -exec sed -Ei  's/^-> (.*)/::alert{type="info"}\n\1\n::/g' {} +
-          find . -type f -name "*.md" -exec sed -Ei  's/^~> (.*)/::alert{type="warning"}\n\1\n::/g' {} +
-          find . -type f -name "*.md" -exec sed -Ei  's/^!> (.*)/::alert{type="danger"}\n\1\n::/g' {} +
-          
-          sed -Ei  's/page_title: "([^ ]+).*"/title: Provider configurations/g' index.md
-          sed -Ei  's/^# kestra Provider/# Provider configurations/g' index.md
-          mv index.md guides/configurations.md
-          
-          mkdir -p ../../docs/content/docs/13.terraform/
-          cp -R * ../../docs/content/docs/13.terraform/
+          terraform-provider-kestra/.github/scripts/docs-to-website.sh \
+            terraform-provider-kestra/docs \
+            docs/src/contents/docs/13.terraform
 
       - name: Generate docs app token
         id: docs-app-token
@@ -65,7 +49,8 @@ jobs:
         run: |
           cd docs
           BRANCH="chore/terraform-docs-${{ github.ref_name }}"
-          git add content/docs/13.terraform/
+          git add src/contents/docs/13.terraform/
+          git rm -r --quiet --ignore-unmatch content/docs/13.terraform
           git diff --cached --quiet && { echo "No docs changes, skipping."; exit 0; }
           git checkout -b "$BRANCH"
           git -c user.name="github-actions[bot]" -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \


### PR DESCRIPTION
### What changes are being made and why?

The docs workflow has been publishing into a directory the website stopped reading in January. `.github/workflows/docs.yml` copied the tfplugindocs output into `content/docs/13.terraform` on `kestra-io/docs`, but that repo moved to Astro in kestra-io/docs#3049 and its docs collection is loaded from `src/contents/docs` (`src/content.config.ts`). Every release since has opened a PR that nothing renders, the last one being kestra-io/docs#5500.

The transform moves into `.github/scripts/docs-to-website.sh` and writes `src/contents/docs/13.terraform/<page>/index.md`, the layout the collection expects. Fixes to the old sed chain along the way:

- `:::alert{type="..."}` containers instead of the Nuxt `::alert` leaf syntax. Under remark-directive the two-colon form is a leaf directive, so the alert body was being dropped.
- Relative `.md` links rewritten for the website page layout (`../resources/flow.md` becomes `../../resources/flow/index.md`).
- The generated H1 is demoted to H2, since the website renders the H1 from frontmatter. Only the leading heading is touched, so `# Before` / `# After` comments inside hcl samples survive.
- Existing frontmatter on the website is kept and only the body is refreshed, so the SEO titles and descriptions there survive a release.
- Guides already published are left untouched and listed in the job log, since they get edited in place on the website.
- A title is derived from the leading heading when a page has no frontmatter upstream. The docs collection requires one, and the migration guides carry none.
- Both paths are resolved to absolute before the transform runs from its temp copy.

The step that opens the PR now also drops the legacy directory if it is still there, so the two repos can be merged in either order.

Companion PR, which lands the output of this script plus the nine pages that never reached the website: kestra-io/docs#5517

---

### How the changes have been QAed?

Ran the script against `docs/` at v2.0.0 and a checkout of the website:

```
$ .github/scripts/docs-to-website.sh docs ../docs/src/contents/docs/13.terraform
Mirrored the provider docs into /home/user/docs/src/contents/docs/13.terraform
Guides already on the website, left untouched: guides/configurations.md guides/working-with-yaml.md
```

- 46 pages written, 9 of them new, and a second run is a no-op (identical checksums), so releases without doc changes still skip the PR.
- Validated the 50 resulting pages: every one has a title, no Nuxt-style directives are left, no un-rewritten ```` ```terraform ```` fences, and every relative `.md` link resolves to a file that exists.
- Frontmatter of the existing pages is byte-identical before and after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TycM4jfMXSVxvzmBPWhPGD